### PR TITLE
Excludes docker files from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -132,6 +132,8 @@ exclude:
   - Gemfile.lock
   - pa11y-ci-results.json
   - pa11y-results
+  - Dockerfile
+  - docker-compose.yml  
 
 assets:
   autoprefixer:


### PR DESCRIPTION
- Excludes `Dockerfile` and `docker-compose.yml` from building and generating in `_site`.