### PR TITLE
Suppress directory warnings

### DIFF
--- a/_plugins/symlink_detector.rb
+++ b/_plugins/symlink_detector.rb
@@ -1,0 +1,12 @@
+# Listen >=2.8 patch to silence duplicate directory errors
+require 'listen/record/symlink_detector'
+
+module Listen
+  class Record
+    class SymlinkDetector
+      def _fail(_, _)
+        fail Error, "Don't watch locally-symlinked directory twice"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolve the multiple:
```
** ERROR: directory is already being watched! **
```
warnings being generated while serving Jekyll locally.