### PR TITLE
Create icon list component

### DIFF
--- a/_includes/icon-list.html
+++ b/_includes/icon-list.html
@@ -1,0 +1,35 @@
+{% assign list = include.list | strip | newline_to_br | strip_newlines | split: "<br />" %}
+
+<ul class="usa-icon-list margin-bottom-2">
+{% for item in list %}
+  {% assign array = item | split: "|" %}
+  {% assign content = array[0] | strip | replace_first: "- ", "" %}
+  {% assign type = array[1] | strip | default: include.type %}
+
+  <li class="usa-icon-list__item">
+    {% case type %}
+      {% when "green-check" %}
+      <div class="usa-icon-list__icon text-green">
+        <svg class="usa-icon" aria-hidden="true" role="img">
+          <use xlink:href="{{ '/img/sprite.svg#check_circle' | relative_url }}"></use>
+        </svg>
+      </div>
+      {% when "red-x" %}
+      <div class="usa-icon-list__icon text-red">
+        <svg class="usa-icon" aria-hidden="true" role="img">
+          <use xlink:href="{{ '/img/sprite.svg#cancel' | relative_url }}"></use>
+        </svg>
+      </div>
+      {% when "error" %}
+      <div class="usa-icon-list__icon">
+        <svg class="usa-icon" aria-hidden="true" role="img">
+          <use xlink:href="{{ '/img/sprite.svg#error' | relative_url }}"></use>
+        </svg>
+      </div>
+    {% endcase %}
+    <div class="usa-icon-list__content">
+      {{content}}
+    </div>
+  </li>
+{% endfor %}
+</ul>

--- a/_pages/understanding/parking.md
+++ b/_pages/understanding/parking.md
@@ -25,11 +25,12 @@ Accessible parking spaces must have access aisles. Access aisles provide a desig
 <div class="grid-container" markdown="0">
   <div class="grid-row">
     <div class="tablet:grid-col-6">
-      <ul class="icon-list">
-        <li>marked (to discourage parking in them)</li>
-        <li>the same length as the space it serves</li>
-        <li>and level with the parking space it serves</li>
-      </ul>
+      {% capture list %}
+      - marked (to discourage parking in them)
+      - the same length as the space it serves
+      - and level with the parking space it serves
+      {% endcapture %}
+      {% include icon-list.html list=list type="green-check" %}
     </div>
     <div class="tablet:grid-col-6">{% asset project-images/aisle-parking.png alt="A van-accessible parking space sharing an access aisle with an accessible parking space for a car" %}</div>
   </div>
@@ -48,13 +49,14 @@ Accessible parking spaces must be provided for cars and vans.
 <div class="grid-container" markdown="0">
   <div class="grid-row">
     <div class="tablet:grid-col-6">
-      <ul class="icon-list">
-        <li>be at least 96 inches wide</li>
-        <li>have an access aisle at least 60 inches wide</li>
-        <li>have no more than a 2% slope in all directions</li>
-        <li>have a surface that is firm, stable and slip-resistant</li>
-        <li>have a sign with the international symbol of accessibility on it, mounted at least 60 inches above the ground (measured to the bottom of the sign)</li>
-      </ul>
+      {% capture list %}
+      - be at least 96 inches wide
+      - have an access aisle at least 60 inches wide
+      - have no more than a 2% slope in all directions
+      - have a surface that is firm, stable and slip-resistant
+      - have a sign with the international symbol of accessibility on it, mounted at least 60 inches above the ground (measured to the bottom of the sign)
+      {% endcapture %}
+      {% include icon-list.html list=list type="green-check" %}
     </div>
       <div class="tablet:grid-col-6">{% asset project-images/car-accessible.png alt="Accessible parking spaces with 60-inch minimum width access aisle for cars" %}</div>
   </div>
@@ -65,15 +67,16 @@ Accessible parking spaces must be provided for cars and vans.
 <div class="grid-container" markdown="0">
   <div class="grid-row">
     <div class="tablet:grid-col-6">
-      <ul class="icon-list">
-        <li>be at least 96 inches wide</li>
-        <li>have an access aisle at least 96 inches wide</li>
-        <li>have no more than a 2% slope in all directions</li>
-        <li>have a surface that is firm, stable and slip-resistant</li>
-        <li>have two signs, mounted at least 60 inches above the ground (measured to the bottom of the sign)</li>
-        <li>first sign - international symbol of accessibility</li>
-        <li>second sign - stating that the space is van accessible</li>
-      </ul>
+      {% capture list %}
+      - be at least 96 inches wide
+      - have an access aisle at least 96 inches wide
+      - have no more than a 2% slope in all directions
+      - have a surface that is firm, stable and slip-resistant
+      - have two signs, mounted at least 60 inches above the ground (measured to the bottom of the sign)
+      - first sign - international symbol of accessibility
+      - second sign - stating that the space is van accessible
+      {% endcapture %}
+      {% include icon-list.html list=list type="green-check" %}
     </div>
       <div class="tablet:grid-col-6">{% asset project-images/van-accessible.png alt="Minimum 96-inch wide van-accessible parking space with 96-inch minimum width access aisle" %}</div>
   </div>
@@ -154,11 +157,12 @@ Where parking spaces are limited to 4 or fewer spaces:
 <div class="grid-container" markdown="0">
   <div class="grid-row">
     <div class="tablet:grid-col-6">
-      <ul class="icon-list">
-        <li>one (1) van accessible parking space must be provided</li>
-        <li>not required to have a sign with the international symbol of accessibility</li>
-        <li>anyone can park in that space</li>
-      </ul>
+      {% capture list %}
+      - one (1) van accessible parking space must be provided
+      - not required to have a sign with the international symbol of accessibility
+      - anyone can park in that space | red-x
+      {% endcapture %}
+      {% include icon-list.html list=list type="green-check" %}
     </div>
     <div class="tablet:grid-col-6">{% asset project-images/limited-spaces.png alt="Front of a convenience store with four parking spaces, one parking space is a van-accessible space" %}</div>
   </div>
@@ -167,16 +171,22 @@ Where parking spaces are limited to 4 or fewer spaces:
 ### Parking at hospital facilities
 
 #### Hospital outpatient facilities
-
-ten percent (10%) of patient and visitor parking must be accessible
+{% capture list %}
+- ten percent (10%) of patient and visitor parking must be accessible
+{% endcapture %}
+{% include icon-list.html list=list type="error" %}
 
 #### Rehabilitation facilities
-
-twenty percent (20%) of patient and visitor parking must be accessible
+{% capture list %}
+- twenty percent (20%) of patient and visitor parking must be accessible
+{% endcapture %}
+{% include icon-list.html list=list type="error" %}
 
 #### Outpatient physical therapy facilities
-
-twenty percent (20%) of patient and visitor parking must be accessible
+{% capture list %}
+- twenty percent (20%) of patient and visitor parking must be accessible
+{% endcapture %}
+{% include icon-list.html list=list type="error" %}
 
 ## Need more information about accessible parking
 

--- a/_pages/understanding/service-animals.md
+++ b/_pages/understanding/service-animals.md
@@ -12,15 +12,20 @@ lead: |-
 ## About Service Animals
 
 ### Service animals are:
+{% capture list %}
 - Dogs
 - Any breed and any size of dog
 - Trained to perform a task directly related to a person’s disability
-
+{% endcapture %}
+{% include icon-list.html list=list type="green-check" %}
 
 ### Service animals are not:
+{% capture list %}
 - Required to be certified or go through a professional training program
 - Required to wear a vest or other ID that indicates they’re a service dog
 - Emotional support or comfort dogs, because providing emotional support or comfort is not a task related to a person’s disability
+{% endcapture %}
+{% include icon-list.html list=list type="red-x" %}
 
 <details>
 <summary>
@@ -68,12 +73,18 @@ The [Equal Employment Opportunity Commission](https://www.eeoc.gov/disability-di
 If you are working at a business or state/local government facility and it is unclear to you whether someone’s dog is a service dog, **you may ask for certain information using two questions**.
 
 ### You may ask:
+{% capture list %}
 - Is the dog a service animal required because of a disability?
 - What work or task has the dog been trained to perform?
+{% endcapture %}
+{% include icon-list.html list=list type="green-check" %}
 
 ### You are _not_ allowed to:
+{% capture list %}
 - Request any documentation that the dog is registered, licensed, or certified as a service animal
 - Require that the dog demonstrate its task, or inquire about the nature of the person’s disability
+{% endcapture %}
+{% include icon-list.html list=list type="red-x" %}
 
 Because service animals are not required to wear vests, a dog that is wearing a vest is not necessarily a service animal. The dog still needs to be trained to perform a task for a person with a disability to be a service animal.
 
@@ -106,12 +117,18 @@ Learn more in <a href="https://www.ada.gov/regs2010/service_animal_qa.html#exc">
 ## State and Local Laws
 
 ### State/local governments can:
+{% capture list %}
 - Require service dogs to be licensed and vaccinated, if all dogs are required to be licensed and vaccinated
 - Offer <em>voluntary</em> service dog registration programs
+{% endcapture %}
+{% include icon-list.html list=list type="green-check" %}
 
 ### State/local governments can't:
+{% capture list %}
 - Require certification or registration of service dogs
 - Ban a service dog based on its breed
+{% endcapture %}
+{% include icon-list.html list=list type="red-x" %}
 
 ## Learn More About the ADA and Service Animals
 The following technical assistance documents provide more helpful information about service animals:


### PR DESCRIPTION
Adds the ability to use icon based lists using liquid rather than HTML. Current icons supported: green-check, red-x, error.

<img width="625" alt="Screen Shot 2021-04-14 at 3 08 30 PM" src="https://user-images.githubusercontent.com/1178494/114765596-56cb7780-9d33-11eb-90ff-79bddcc59e14.png">

Example syntax:
```
{% capture list %}
- one (1) van accessible parking space must be provided
- not required to have a sign with the international symbol of accessibility
- anyone can park in that space | red-x
{% endcapture %}
{% include icon-list.html list=list type="green-check" %}
```