### PR TITLE
Prevent layout shift on nav link hover

### DIFF
--- a/_assets/css/custom/header.scss
+++ b/_assets/css/custom/header.scss
@@ -47,7 +47,6 @@
     max-height: 2rem;
   }
 
-  // again overriding USWDS defaults
   .crt-landing--menu_link {
     color: color($theme-color-primary-darker) !important;
     font-size: $theme-text-font-size-md;
@@ -62,6 +61,26 @@
       border-bottom: 1px solid transparent;
       margin-top: 0.5rem;
       padding: 0.5rem 0 !important;
+      align-items: center;
+      display: inline-flex !important;
+      flex-direction: column;
+      justify-content: space-between;
+
+      &:after {
+        content: attr(data-text);
+        content: attr(data-text) / "";
+        display: block !important;
+        height: 0;
+        visibility: hidden;
+        overflow: hidden;
+        user-select: none;
+        pointer-events: none;
+        font-weight: bold;
+
+        @media speech {
+          display: none;
+        }
+      }
 
       &:hover,
       &.usa-current {
@@ -108,6 +127,6 @@
   .usa-nav.is-visible {
     background-color: color($theme-color-primary-lightest);
     color: color($theme-color-primary-darker);
-    @include u-shadow(2)
+    @include u-shadow(2);
   }
 }

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -13,6 +13,7 @@
           <a
             class="crt-landing--menu_link{% if nav_item.url == page.permalink or page.url contains nav_item.url or page.permalink contains nav_item.url %} usa-current{% endif %}"
             href="{{ nav_item.url | prepend: site.baseurl}}"
+            data-text="{{ nav_item.name | escape }}"
             >{{ nav_item.name | escape }}</a
           >
         </li>


### PR DESCRIPTION
Prevents the small shift in the top navigation links on hover:

<img width="411" alt="Screen Shot 2021-04-21 at 3 11 53 PM" src="https://user-images.githubusercontent.com/1178494/115608238-02d10d80-a2b4-11eb-8eeb-7531c445d26f.png">
