### PR TITLE
Remove comma from site logo

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -11,7 +11,7 @@
         {{ site.title }}
       </p>
       <p class="crt-landing--logo_subheading">
-        U.S. Department of Justice,<br />
+        U.S. Department of Justice<br />
         Civil Rights Division
       </p>
     </div>


### PR DESCRIPTION
Removes comma after Civil Rights Division

<img width="326" alt="Screen Shot 2021-04-21 at 3 39 18 PM" src="https://user-images.githubusercontent.com/1178494/115611215-cacbc980-a2b7-11eb-833a-1f7803e7d76f.png">
