### PR TITLE
Make entire card clickable

### DIFF
--- a/_assets/css/custom/card.scss
+++ b/_assets/css/custom/card.scss
@@ -1,3 +1,22 @@
+.usa-card__container {
+  position: relative;
+
+  a:after {
+    content: "";
+    @include u-position("absolute");
+    @include u-top(0);
+    @include u-left(0);
+    @include u-right(0);
+    @include u-bottom(0);
+  }
+
+  &:hover {
+    box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+    transition: all 0.3s ease;
+  }
+}
+
 @include at-media(desktop) {
   .usa-card:last-child {
     margin-bottom: 1rem;


### PR DESCRIPTION
Makes the entire card area clickable on the landing page and adds subtle hover effect.

<img width="350" alt="Screen Shot 2021-04-21 at 4 44 00 PM" src="https://user-images.githubusercontent.com/1178494/115618512-cc4dbf80-a2c0-11eb-99a8-5b5d3e183255.png">
