### PR TITLE
Tweak spacing of elements on overlay page

### DIFF
--- a/_assets/css/custom/page.scss
+++ b/_assets/css/custom/page.scss
@@ -7,7 +7,11 @@
       color: color($theme-text-color);
 
       &.usa-current {
-        color: color($theme-color-primary-dark);
+        color: color($theme-color-primary-darker);
+
+        &:after {
+          background-color: color($theme-color-primary-darker);
+        }
       }
     }
   }
@@ -19,16 +23,28 @@
   }
 
   h1 {
-    margin-top: 0;
+    margin: 0;
   }
 
-  & > h2 {
+  h2:not(.usa-alert__heading) {
+    margin-top: 3rem;
+
     &:after {
       content: "";
       display: block;
       margin-top: 0.5rem;
       @extend .crt-landing--separator_sub;
     }
+  }
+
+  h3 {
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+  }
+
+  h3 {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
   }
 
   details > summary > p {

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,7 @@ associated with it. For example, an about page. {% endcomment %}
       </div>
       <div class="tablet:grid-col-8 tablet:grid-offset-1">
         <h1>{{page.title}}</h1>
-        <div class="crt-landing--separator"></div>
+        <div class="crt-landing--separator_small"></div>
         {% include alert-proto.html %}
         {% if page.lead %}
         <div class="crt-lead">


### PR DESCRIPTION
This adjusts the spacing before headings on the overlay page template, as well as adding the small blue accent beneath `h2`s, and adjusting the side nav link color.