### PR TITLE
Add smooth scrolling to supported browsers

### DIFF
--- a/_assets/css/custom/_all.scss
+++ b/_assets/css/custom/_all.scss
@@ -8,6 +8,7 @@
 @import "typography";
 @import "separator";
 @import "sidenav";
+@import "smooth-scroll";
 
 // Layout specific
 @import "landing";

--- a/_assets/css/custom/_smooth-scroll.scss
+++ b/_assets/css/custom/_smooth-scroll.scss
@@ -1,0 +1,9 @@
+html {
+  scroll-behavior: smooth;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
The scroll-behavior property works in most modern browsers. It does not work in Safari or mobile Safari. It also has no IE support.