### PR TITLE
Applies DRS style guide to landing page

### DIFF
--- a/_includes/landing/report.html
+++ b/_includes/landing/report.html
@@ -7,7 +7,7 @@
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-12">
         <h2 class="h1 text__reverse" id="report-a-violation">
-          How to report a disability rights violation
+          How to Report a Disability Rights Violation
         </h2>
         <div class="crt-landing--separator_small"></div>
       </div>

--- a/_includes/landing/understand.html
+++ b/_includes/landing/understand.html
@@ -3,7 +3,7 @@
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-10">
         <h2 class="h1">
-          Understand the basics of ADA
+          Understand the Basics of the ADA
         </h2>
         <div class="crt-landing--separator"></div>
         <p class="crt-landing--lead">
@@ -15,7 +15,7 @@
         <div class="grid-row grid-gap">
           <p class="crt-landing--largetext">
             <strong>Pick a topic to find out how the ADA works.</strong> We’ll
-            be adding more guides soon.
+            add more guides soon.
           </p>
           <ul class="usa-card-group">
             {% for card in include.cards %}

--- a/_pages/guides/parking.md
+++ b/_pages/guides/parking.md
@@ -5,7 +5,7 @@ permalink: /guides/parking/
 lead: |-
   When state or local governments, businesses and nonprofit organizations provide customer or employee parking in parking lots or garages, accessible parking spaces complying with the Americans with Disabilities Act (ADA) must be provided.
 
-  Accessible parking spaces are different then traditional parking spaces. They have specific features that make it easier for people with disabilities to access your programs, goods or services.
+  Accessible parking spaces are different than traditional parking spaces. They have specific features that make it easier for people with disabilities to access your programs, goods or services.
 ---
 
 ## Features of accessible parking spaces

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -46,7 +46,7 @@ cards:
     href: /guides/service-animals/
   - title: Parking
     description: |-
-      Parking ipsum dolor sit amet, conset tur adipiscing elit, sed do eiusmod.
+      Learn about accessible parking features that make it easier for people with disabilities to access programs, goods, and services.
     image: landing/Parking-placeholder.png
     alt: A man in a wheelchair approaching a vehicle with his hand on the door handle
     href: /guides/parking/

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -5,7 +5,7 @@ title: Home
 
 alert:
   content: |-
-    _We're working to make ADA.gov more useful and accessible. We've launched this beta to share our work in progress. Let us know how we're doing so far._
+    _We're working to make ADA.gov more useful and accessible. We've launched this beta site to share our work in progress. Let us know how we're doing so far._
   heading: |-
     Help us improve ADA.gov
   link:


### PR DESCRIPTION
The DRS style guide uses title case for headings. We've slightly modified this rule for ada.gov to allow for sentence case when a heading is an independent clause accompanied by punctuation.