### PR TITLE
Make sticky nav scrollable

### DIFF
--- a/_assets/css/custom/_sidenav.scss
+++ b/_assets/css/custom/_sidenav.scss
@@ -18,6 +18,11 @@
 
   .usa-accordion {
     margin-bottom: 2rem;
+
+    @include at-media(desktop) {
+      max-height: calc(100vh - 1.5rem * 2);
+      overflow-y: auto;
+    }
   }
 
   .usa-accordion__button {
@@ -38,9 +43,9 @@
   }
 
   @include at-media(desktop) {
-    @include u-position('sticky');
+    @include u-position("sticky");
     @include u-top(3);
-    @include u-flex('align-self-start');
+    @include u-flex("align-self-start");
 
     .usa-accordion__content {
       background: none;


### PR DESCRIPTION
Allows left nav to be scrollable when there is not sufficient height to show all of the links (on desktop).