### PR TITLE
Add custom icon list liquid tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,8 @@ assets:
   raw_precompile:
     - source: node_modules/uswds/dist/fonts/**/*
       strip: node_modules/uswds/dist/
+    - source: node_modules/uswds/dist/img/sprite.svg
+      strip: node_modules/uswds/dist/
   sources:
     - node_modules/gumshoejs/dist
     - node_modules/uswds/dist

--- a/_pages/guides/mobility-devices.md
+++ b/_pages/guides/mobility-devices.md
@@ -64,25 +64,20 @@ After considering these factors, an agency or business might establish a policy 
 
 If a person with a disability enters a business or government facility using an OPDMD:
 
-{% capture list %}
+{% list %}
+{% list_item check_circle %}
 You may ask that they provide “credible assurance” that the device is used because of a disability.
-{% endcapture %}
-{% include icon-list.html list=list type="green-check" %}
-<details>
-<summary>
+
 You must accept any of these types of credible assurance:
-</summary>
+
 - A valid, state-issued disability parking placard
 - Other state-issued proof of disability
 - A statement from the person that the OPDMD is used because of a disability, unless the person is observed doing something that contradicts this statement
-</details>
-
-
-{% capture list %}
+{% endlist_item %}
+{% list_item cancel %}
 You may not ask about the nature or extent of someone’s disability. This is also true if someone is using a wheelchair or other manual mobility aid.
-{% endcapture %}
-{% include icon-list.html list=list type="red-x" %}
-
+{% endlist_item %}
+{% endlist %}
 
 ## Learn more about the ADA and Mobility Devices
 

--- a/_plugins/icon_list.rb
+++ b/_plugins/icon_list.rb
@@ -1,0 +1,64 @@
+module Jekyll
+  module Tags
+    class ListTag < Liquid::Block
+      def initialize(tag_name, block_options, liquid_options)
+        super
+      end
+
+      def render(context)
+        context.stack do
+          @content = super
+        end
+
+        output = %(<ul class="usa-icon-list margin-bottom-2">#{@content}</ul>)
+
+        output
+      end
+    end
+
+    class ListItemTag < Liquid::Block
+      include Jekyll::Filters::URLFilters
+
+      def initialize(tag_name, block_options, liquid_options)
+        super
+        @icon_type = block_options.strip
+      end
+
+      def render(context)
+        @context = context
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        content = converter.convert(super)
+
+        output = <<~EOS
+          <li class="usa-icon-list__item">
+            <div class="usa-icon-list__icon #{text_color(@icon_type)}">
+              <svg class="usa-icon" aria-hidden="true" role="img">
+                <use xlink:href="#{relative_url("assets/img/sprite.svg")}##{@icon_type}"></use>
+              </svg>
+            </div>
+            <div class="usa-icon-list__content">
+              #{content}
+            </div>
+          </li>
+        EOS
+
+        output
+      end
+
+      private
+
+      def text_color(icon)
+        case icon
+        when "check_circle"
+          "text-green"
+        when "cancel"
+          "text-red"
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('list', Jekyll::Tags::ListTag)
+Liquid::Template.register_tag('list_item', Jekyll::Tags::ListItemTag)


### PR DESCRIPTION
More streamlined approach similar to accordion tag, also allows for large blocks of content to be associated with each bullet rather than only allowing a single line of content.