### PR TITLE
Add additional skip link for overlay page layout

### DIFF
--- a/_assets/css/custom/_page.scss
+++ b/_assets/css/custom/_page.scss
@@ -2,9 +2,10 @@
   padding-top: 3rem;
   padding-bottom: 3rem;
 
-  .crt-page--content {
+  #crt-page--content {
     .crt-lead {
-      > p, li {
+      > p,
+      li {
         @include text--heading__medium();
       }
     }

--- a/_assets/css/custom/_sidenav.scss
+++ b/_assets/css/custom/_sidenav.scss
@@ -3,7 +3,7 @@
   margin-right: 0;
 }
 
-.crt-page--sidenav {
+#crt-page--sidenav {
   a {
     color: color($theme-text-color);
 
@@ -57,7 +57,7 @@
       }
     }
 
-    .usa-sidenav__sublist{
+    .usa-sidenav__sublist {
       a {
         @include text--body-copy__small();
       }

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -6,30 +6,30 @@
       Table of contents
     </button>
   </h4>
-    <nav>
-      {% assign _url = page.url | split: '/' %}
-      {% assign _parent_dir = _url[1] %}
-      {% assign _parent_path = _parent_dir | append: '/index.md' %}
-      {% assign _pages = site.pages | where_exp:"item", "item.url contains _parent_dir" %}
-      <div id="toc" class="usa-accordion__content">
-        <ul class="usa-sidenav {% if _pages.size < 2 %}border-bottom-0{% endif %}">
-          {% for _page in _pages %}
-          {% unless _page.path contains "index.md" or _page.hidden %}
-          <li class="usa-sidenav__item">
-            <a href="{{ _page.url | relative_url }}" {% if _page.url==page.url %}class="usa-current" {% endif %}>{% if _page.short_title %}{{ _page.short_title }}{% else %}{{ _page.title }}{% endif %}</a>
-            {% if _page.url == page.url and page.subnav%}
-            <ul class="usa-sidenav__sublist">
-              {% for _anchor in page.subnav %}
-              <li class="usa-sidenav__item">
-                <a href="{{_anchor.url | relative_url}}">{{_anchor.title}}</a>
-              </li>
-              {% endfor %}
-            </ul>
-            {% endif %}
-          </li>
-          {% endunless %}
-          {% endfor %}
-        </ul>
-      </div>
-    </nav>
+  <nav>
+    {% assign _url = page.url | split: '/' %}
+    {% assign _parent_dir = _url[1] %}
+    {% assign _parent_path = _parent_dir | append: '/index.md' %}
+    {% assign _pages = site.pages | where_exp:"item", "item.url contains _parent_dir" %}
+    <div id="toc" class="usa-accordion__content">
+      <ul class="usa-sidenav {% if _pages.size < 2 %}border-bottom-0{% endif %}">
+        {% for _page in _pages %}
+        {% unless _page.path contains "index.md" or _page.hidden %}
+        <li class="usa-sidenav__item">
+          <a href="{{ _page.url | relative_url }}" {% if _page.url==page.url %}class="usa-current" {% endif %}>{% if _page.short_title %}{{ _page.short_title }}{% else %}{{ _page.title }}{% endif %}</a>
+          {% if _page.url == page.url and page.subnav%}
+          <ul class="usa-sidenav__sublist">
+            {% for _anchor in page.subnav %}
+            <li class="usa-sidenav__item">
+              <a href="{{_anchor.url | relative_url}}">{{_anchor.title}}</a>
+            </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </li>
+        {% endunless %}
+        {% endfor %}
+      </ul>
+    </div>
+  </nav>
 </div>

--- a/_includes/skipnav.html
+++ b/_includes/skipnav.html
@@ -5,6 +5,6 @@
 {% endif %}
 
 {% if has_side_nav %}
-<a class="usa-skipnav" href="#crt-page--sidenav">Skip to in-page navigation</a>
+<a class="usa-skipnav" href="#crt-page--sidenav">Skip to page navigation</a>
 {% endif %}
 <a class="usa-skipnav" href="#{% if has_side_nav %}crt-page--content{% else %}main-content{% endif %}">Skip to main content</a>

--- a/_includes/skipnav.html
+++ b/_includes/skipnav.html
@@ -1,1 +1,10 @@
-<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+{% if page.layout == 'page' and page.sidenav %}
+  {% assign has_side_nav = true %}
+{% else %}
+  {% assign has_side_nav = false %}
+{% endif %}
+
+{% if has_side_nav %}
+<a class="usa-skipnav" href="#crt-page--sidenav">Skip to in-page navigation</a>
+{% endif %}
+<a class="usa-skipnav" href="#{% if has_side_nav %}crt-page--content{% else %}main-content{% endif %}">Skip to main content</a>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,11 +5,11 @@ layout: default
 <div class="crt-page grid-container">
   <div class="grid-row grid-gap-xl">
     {% if page.sidenav %}
-    <div class="crt-page--sidenav desktop:grid-col-4">
+    <div id="crt-page--sidenav" class="desktop:grid-col-4">
       {% include sidenav.html %}
     </div>
     {% endif %}
-    <div class="crt-page--content tablet:grid-col-8">
+    <div id="crt-page--content" class="tablet:grid-col-8">
       <h1>{{page.title}}</h1>
       <div class="crt-landing--separator_small"></div>
       {% include alert.html %}


### PR DESCRIPTION
Fixes https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/151

This presents users with two skip nav links - the first will redirect focus to the side navigation containing in-page anchor links, and the second skip nav will allow folks to go directly to the content, bypassing the in-page links.

<img width="427" alt="Screen Shot 2021-05-25 at 4 21 18 PM" src="https://user-images.githubusercontent.com/1178494/119563324-62b84980-bd75-11eb-910b-b637a4b01432.png">
