### PR TITLE
Remove robots meta tag

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -4,7 +4,6 @@
     ================================================== -->
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="robots" content="noindex, nofollow" />
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True" />


### PR DESCRIPTION
This tag prevents search engines from indexing pages - we will want to remove this prior to launch.