### PR TITLE
Update footer with DOJ privacy policy

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -92,7 +92,7 @@
               <a href="https://civilrights.justice.gov">
                 Report a violation
               </a>
-              <a href="">
+              <a href="https://www.justice.gov/doj/privacy-policy">
                 Privacy policy
               </a>
               <a href="https://www.justice.gov/crt/freedom-information-act-0">


### PR DESCRIPTION
The privacy policy link in the footer redirects to beta.ada.gov. This PR updates it so it points to the justice.gov policy.