### PR TITLE
Minor edit to beta banner punctuation

### DIFF
--- a/_includes/banner-beta.html
+++ b/_includes/banner-beta.html
@@ -7,7 +7,7 @@
     </div>
     <div class="grid-col-fill">
       <p class="usa-banner__header-text">
-        <strong>This is a BETA site:</strong> an early, in-progress version of
+        <strong>This is a BETA site</strong>. It's an early, in-progress version of
         an improved ADA.gov. If you don't find what you're looking for,
         <a href="https://www.ada.gov">return to the main ADA.gov</a>
       </p>


### PR DESCRIPTION
The current version, which uses a colon, isn't ideal grammatically. This edit omits the colon and separates the clauses with a period instead.