### PR TITLE
Enables USWDS dropdown in global navigation

### DIFF
--- a/_assets/css/custom/_header.scss
+++ b/_assets/css/custom/_header.scss
@@ -16,7 +16,7 @@
     display: flex;
     justify-content: space-between;
 
-    padding: 0 1rem 0 6rem;
+    padding: 0.5rem 1rem 0.5rem 6rem;
 
     @include at-media-max(desktop) {
       padding: 0 1rem;
@@ -60,7 +60,7 @@
     @include at-media(desktop) {
       border-bottom: 1px solid transparent;
       margin-top: 0.5rem;
-      padding: 0.5rem 0 !important;
+      padding: 0.5rem !important;
       align-items: center;
       display: inline-flex !important;
       flex-direction: column;
@@ -79,6 +79,15 @@
 
         @media speech {
           display: none;
+        }
+      }
+
+      &.usa-accordion__button {
+        background-position: right 0.25rem center;
+
+        &[aria-expanded="true"] {
+          color: color("white") !important;
+          font-weight: bold !important;
         }
       }
 

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,11 @@ google_site_verification: 34Ks265Uibpdda984RS0SxVABVZCdlVrdSp61pIdZQ8
 # Site Navigation
 primary_navigation:
   - name: ADA Topics
-    url: /topics/
+    children:
+      - name: Intro to ADA
+        url: "/topics/intro-to-ada/"
+      - name: Service Animals
+        url: "/topics/service-animals/"
   - name: File a Complaint
     url: https://civilrights.justice.gov/report/
     external: true

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ google_site_verification: 34Ks265Uibpdda984RS0SxVABVZCdlVrdSp61pIdZQ8
 primary_navigation:
   - name: ADA Topics
     children:
-      - name: Intro to ADA
+      - name: Introduction to ADA
         url: "/topics/intro-to-ada/"
       - name: Service Animals
         url: "/topics/service-animals/"

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -14,7 +14,7 @@
           <li class="usa-nav__primary-item">
             <a class="crt-landing--menu_link usa-nav__link{% if basedir == linkdir %} usa-current{% endif %}"
               data-text="{{ nav_item.name | escape }}"
-              href="{{ nav_item.url | prepend: site.baseurl}}"><span>{{ nav_item.name | escape }}</span></a>
+              href="{% if nav_item.external %}{{ nav_item.url }}{% else %}{{ nav_item.url | relative_url }}{% endif %}"><span>{{ nav_item.name | escape }}</span></a>
           </li>
           {% else %}
           {% assign nav_id = 'primary-nav-' | append: forloop.index %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -3,22 +3,38 @@
     <div class="crt-menu--navbar">
       <button class="crt-menu--mobile usa-menu-btn">Menu</button>
     </div>
-    <div class="usa-nav">
-      <button class="usa-nav__close">
-        {% asset img/usa-icons/close.svg alt="close" %}
-      </button>
-      <ul class="usa-nav__primary usa-accordion">
-        {% for nav_item in include.primary_navigation %}
-        <li class="usa-nav__primary-item">
-          <a
-            class="crt-landing--menu_link{% if nav_item.url == page.permalink or page.url contains nav_item.url or page.permalink contains nav_item.url %} usa-current{% endif %}{% if nav_item.classes %} {{ nav_item.classes }}{% endif %}"
-            href="{% if nav_item.external %}{{ nav_item.url }}{% else %}{{ nav_item.url | relative_url }}{% endif %}"
-            data-text="{{ nav_item.name | escape }}"
-            >{{ nav_item.name | escape }}</a
-          >
-        </li>
-        {% endfor %}
-      </ul>
+    <div role="navigation" class="usa-nav">
+      <div class="usa-nav__inner">
+        <button class="usa-nav__close">{% asset img/usa-icons/close.svg alt="close" %}</button>
+        <ul class="usa-nav__primary usa-accordion">
+          {% for nav_item in include.primary_navigation %}
+          {% unless nav_item.children %}
+          {% assign basedir = page.url | remove_first: '/' | split: '/' | first | lstrip %}
+          {% assign linkdir = nav_item.url |  replace: "/", ""  | lstrip %}
+          <li class="usa-nav__primary-item">
+            <a class="crt-landing--menu_link usa-nav__link{% if basedir == linkdir %} usa-current{% endif %}"
+              data-text="{{ nav_item.name | escape }}"
+              href="{{ nav_item.url | prepend: site.baseurl}}"><span>{{ nav_item.name | escape }}</span></a>
+          </li>
+          {% else %}
+          {% assign nav_id = 'primary-nav-' | append: forloop.index %}
+          <li class="usa-nav__primary-item">
+            <button class="crt-landing--menu_link usa-accordion__button usa-nav__link" aria-expanded="false"
+              data-text="{{ nav_item.name | escape }}"
+              aria-controls="{{ nav_id }}"><span>{{ nav_item.name | escape }}</span></button>
+            <ul id="{{ nav_id }}" class="usa-nav__submenu">
+              {% for subnav_item in nav_item.children %}
+              <li class="usa-nav__submenu-item">
+                <a href="{{ subnav_item.url | prepend: site.baseurl }}">{{ subnav_item.name | escape }}</a>
+              </li>
+              {% endfor %}
+            </ul>
+
+          </li>
+          {% endunless %}
+          {% endfor %}
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -3,7 +3,7 @@
     <div class="crt-menu--navbar">
       <button class="crt-menu--mobile usa-menu-btn">Menu</button>
     </div>
-    <div role="navigation" class="usa-nav">
+    <div role="navigation" class="usa-nav" aria-label="Primary navigation">
       <div class="usa-nav__inner">
         <button class="usa-nav__close">{% asset img/usa-icons/close.svg alt="close" %}</button>
         <ul class="usa-nav__primary usa-accordion">

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -8,7 +8,7 @@
       Table of contents
     </button>
   </h4>
-  <nav id="toc" class="usa-accordion__content">
+  <nav id="toc" class="usa-accordion__content" aria-label="Page navigation">
     <ul class="usa-sidenav">
       <li class="usa-sidenav__item">
         <a href="#top" class="usa-current">{% if page.short_title %}{{ page.short_title }}{% else %}{{ page.title }}{% endif %}</a>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,35 +1,25 @@
 <div class="usa-accordion">
   <h4 class="usa-accordion__heading desktop:display-none">
-    <button class="usa-accordion__button"
+    <button
+      class="usa-accordion__button"
       aria-expanded="false"
-      aria-controls="toc">
+      aria-controls="toc"
+    >
       Table of contents
     </button>
   </h4>
-  <nav>
-    {% assign _url = page.url | split: '/' %}
-    {% assign _parent_dir = _url[1] %}
-    {% assign _parent_path = _parent_dir | append: '/index.md' %}
-    {% assign _pages = site.pages | where_exp:"item", "item.url contains _parent_dir" %}
-    <div id="toc" class="usa-accordion__content">
-      <ul class="usa-sidenav {% if _pages.size < 2 %}border-bottom-0{% endif %}">
-        {% for _page in _pages %}
-        {% unless _page.path contains "index.md" or _page.hidden %}
-        <li class="usa-sidenav__item">
-          <a href="{{ _page.url | relative_url }}" {% if _page.url==page.url %}class="usa-current" {% endif %}>{% if _page.short_title %}{{ _page.short_title }}{% else %}{{ _page.title }}{% endif %}</a>
-          {% if _page.url == page.url and page.subnav%}
-          <ul class="usa-sidenav__sublist">
-            {% for _anchor in page.subnav %}
-            <li class="usa-sidenav__item">
-              <a href="{{_anchor.url | relative_url}}">{{_anchor.title}}</a>
-            </li>
-            {% endfor %}
-          </ul>
-          {% endif %}
-        </li>
-        {% endunless %}
-        {% endfor %}
-      </ul>
-    </div>
+  <nav id="toc" class="usa-accordion__content">
+    <ul class="usa-sidenav">
+      <li class="usa-sidenav__item">
+        <a href="#top" class="usa-current">{% if page.short_title %}{{ page.short_title }}{% else %}{{ page.title }}{% endif %}</a>
+        <ul class="usa-sidenav__sublist">
+          {% for anchor in page.subnav %}
+          <li class="usa-sidenav__item">
+            <a href="{{ anchor.url | relative_url }}">{{ anchor.title }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      </li>
+    </ul>
   </nav>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,7 @@ layout: default
     </div>
     {% endif %}
     <div id="crt-page--content" class="tablet:grid-col-8">
-      <h1>{{page.title}}</h1>
+      <h1 id="top">{{page.title}}</h1>
       <div class="crt-landing--separator_small"></div>
       {% if page.lead %}
         <div class="crt-lead">

--- a/_pages/topics/index.md
+++ b/_pages/topics/index.md
@@ -1,5 +1,0 @@
----
-title: ADA Guides
-permalink: /topics/
-redirect_to: /topics/intro-to-ada/
----


### PR DESCRIPTION
This converts `ADA Topics` into a dropdown, allowing direction navigation to overlays from the global nav.

<img width="464" alt="Screen Shot 2021-06-07 at 12 24 54 PM" src="https://user-images.githubusercontent.com/1178494/121055768-8f179100-c78b-11eb-871c-49d426643c37.png">

It also removes the listing of other overlays within the side navigation, displaying only anchor links within the page currently being viewed.
<img width="991" alt="Screen Shot 2021-06-07 at 12 25 18 PM" src="https://user-images.githubusercontent.com/1178494/121055926-b1a9aa00-c78b-11eb-9aa5-4088dc68e257.png">
