### PR TITLE
Update header title

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -9,7 +9,7 @@
     <div class="grid-col-auto">
       <div class="display-flex flex-align-center">
         <p class="crt-landing--logo_heading">
-          {{ site.title }}
+          ADA.gov
         </p>
         {% if site.beta %}
         <span


### PR DESCRIPTION
Switches title in header back to `ADA.gov` rather than:

<img width="451" alt="Screen Shot 2021-06-08 at 9 39 29 AM" src="https://user-images.githubusercontent.com/1178494/121196675-ae232b00-c83e-11eb-8c01-7bea8ac6c84a.png">
