### PR TITLE
Add infoline to mobile flyout

### DIFF
--- a/_assets/css/custom/_header.scss
+++ b/_assets/css/custom/_header.scss
@@ -127,6 +127,10 @@
       margin-bottom: -1rem;
     }
 
+    @include at-media-max(desktop) {
+      width: 18rem;
+    }
+
     &.is-visible {
       background-color: color($theme-color-primary-lightest);
       color: color($theme-color-primary-darker);

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,10 @@ title: "Beta.ADA.gov"
 # custom domains, edit this url parameter in the relevant branch to match the relevant custom domain.
 description: Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
 
+contact:
+  tollfree: 800-514-0301
+  tty: 800-514-0383
+
 # Display beta disclamers
 beta: true
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -65,12 +65,12 @@
                 {% asset phone.svg class="icon" alt="phone" %}
               </div>
               <div id="phone-footer" class="usa-footer__links">
-                <p><a href="tel:1-800-514-0301">1-800-514-0301</a></p>
+                <p><a href="tel:{{ site.contact.tollfree }}">{{ site.contact.tollfree }}</a></p>
 
                 <p>Telephone Device for the Deaf</p>
                 <p>
                   (TTY)
-                  <a href="tel:1-800-514-0383">1-800-514-0383</a>
+                  <a href="tel:{{ site.contact.tty }}">{{ site.contact.tty }}</a>
                 </p>
               </div>
             </div>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -6,7 +6,7 @@
     <div role="navigation" class="usa-nav" aria-label="Primary navigation">
       <div class="usa-nav__inner">
         <button class="usa-nav__close">{% asset img/usa-icons/close.svg alt="close" %}</button>
-        <ul class="usa-nav__primary usa-accordion">
+        <ul class="usa-nav__primary usa-accordion margin-bottom-1">
           {% for nav_item in include.primary_navigation %}
           {% unless nav_item.children %}
           {% assign basedir = page.url | remove_first: '/' | split: '/' | first | lstrip %}
@@ -29,11 +29,21 @@
               </li>
               {% endfor %}
             </ul>
-
           </li>
           {% endunless %}
           {% endfor %}
         </ul>
+        <div
+          class="display-flex desktop:display-none flex-align-start padding-left-6 padding-right-3 bg-primary-lighter margin-x-neg-3 padding-y-3 line-height-sans-5"
+        >
+          {% asset ic_phone-circle.svg class="margin-right-1" alt="phone" %}
+          <div class="">
+            <span class="display-block margin-bottom-05 text-bold">Questions about the ADA?</span>
+            Talk to us at<br />
+            {{ site.contact.tollfree }}<br />
+            {{ site.contact.tty }} (TTY)
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/_includes/phone.html
+++ b/_includes/phone.html
@@ -6,6 +6,6 @@
     <span class="display-block margin-bottom-05 text-bold"
       >Questions about the ADA?</span
     >
-    Talk to us at 800-514-0301 | 800-514-0383 (TTY)
+    Talk to us at {{ site.contact.tollfree }} | {{ site.contact.tty }} (TTY)
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/187

Adds infoline information to mobile menu flyout:
<img width="413" alt="Screen Shot 2021-06-08 at 3 11 16 PM" src="https://user-images.githubusercontent.com/1178494/121243634-eb51e200-c86b-11eb-9c25-b429894de3fa.png">

Also moves the tollfree and TTY numbers to the global config, so that they can be updated in one place.