### PR TITLE
Adds line break to Intro to ADA

### DIFF
--- a/_pages/topics/intro-to-ada.md
+++ b/_pages/topics/intro-to-ada.md
@@ -130,7 +130,7 @@ The ADA contains specific requirements for state and local governments to ensure
 
 **Applies to:**
 
-- Businesses and nonprofits serving the public
+- Businesses and nonprofits serving the public.<br>
 Examples of businesses and nonprofits include:
   - Restaurants
   - Hotels
@@ -142,14 +142,14 @@ Examples of businesses and nonprofits include:
   - Gyms
   - Organizations offering courses or examinations
 
-- Privately operated transit  
+- Privately operated transit.  
 Examples of privately operated transit include:
   - Taxis
   - Intercity and charter buses
   - Hotel shuttles
   - Airport shuttles
 
-- Commercial facilities (need only comply with requirements of the [ADA Standards for Accessible Design](https://www.ada.gov/2010ADAstandards_index.htm))  
+- Commercial facilities (need only comply with requirements of the [ADA Standards for Accessible Design](https://www.ada.gov/2010ADAstandards_index.htm)).  
 Examples of commercial facilities include:
   - Office buildings
   - Warehouses

--- a/_pages/topics/intro-to-ada.md
+++ b/_pages/topics/intro-to-ada.md
@@ -130,7 +130,7 @@ The ADA contains specific requirements for state and local governments to ensure
 
 **Applies to:**
 
-- Businesses and nonprofits serving the public.<br>
+- Businesses and nonprofits serving the public.  
 Examples of businesses and nonprofits include:
   - Restaurants
   - Hotels


### PR DESCRIPTION
There's a punctuation/line break issue in the Introduction to the ADA `Businesses That Are Open to the Public` section. This PR adds a line break and punctuation (since the other sections have punctuation for the same entry).

## Prod
```
Applies to:

- Businesses and nonprofits serving the public Examples of businesses and nonprofits include:
```

## This PR
```
Businesses and nonprofits serving the public.
Examples of businesses and nonprofits include:
```
