### PR TITLE
Add overlay landing page

### DIFF
--- a/_assets/css/custom/_page.scss
+++ b/_assets/css/custom/_page.scss
@@ -14,7 +14,7 @@
       margin: 0;
     }
 
-    h2:not(.usa-alert__heading):not(.usa-accordion__heading) {
+    h2:not(.usa-alert__heading):not(.usa-accordion__heading):not(.usa-card__heading) {
       margin-top: 3rem;
 
       &:after {
@@ -25,7 +25,7 @@
       }
     }
 
-    h3 {
+    h3:not(.usa-card__heading) {
       margin-top: 2.5rem;
       margin-bottom: 1rem;
     }

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -3,9 +3,7 @@
 //= require anchor.min.js
 
 var anchors = new AnchorJS();
-anchors.add(
-  ".crt-page h2:not(.usa-alert__heading):not(.usa-accordion__heading)"
-);
+anchors.add(".crt-page h2:not([class*='usa'])");
 
 var toc = document.getElementById("toc");
 if (toc) {

--- a/_config.yml
+++ b/_config.yml
@@ -44,11 +44,7 @@ google_site_verification: 34Ks265Uibpdda984RS0SxVABVZCdlVrdSp61pIdZQ8
 # Site Navigation
 primary_navigation:
   - name: ADA Topics
-    children:
-      - name: Introduction to ADA
-        url: "/topics/intro-to-ada/"
-      - name: Service Animals
-        url: "/topics/service-animals/"
+    url: "/topics/"
   - name: File a Complaint
     url: https://civilrights.justice.gov/report/
     external: true

--- a/_data/cards.yml
+++ b/_data/cards.yml
@@ -1,0 +1,7 @@
+- card:
+    title: Parking
+    description: |-
+      <em>Coming soon!</em>
+    image: landing/parking.jpg
+    alt: A man in a wheelchair approaching a vehicle with his hand on the door handle
+    position: top

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,7 +1,11 @@
 <li class="tablet:grid-col-4 usa-card">
   <div class="usa-card__container">
     <header class="usa-card__header">
+      {% if include.heading_level == 2 %}
+      <h2 class="usa-card__heading">{{ include.card.card.title }}</h2>
+      {% else %}
       <h3 class="usa-card__heading">{{ include.card.card.title }}</h3>
+      {% endif %}
     </header>
     <div class="usa-card__media">
       <div

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,25 +1,25 @@
 <li class="tablet:grid-col-4 usa-card">
   <div class="usa-card__container">
     <header class="usa-card__header">
-      <h3 class="usa-card__heading">{{ include.card.title }}</h3>
+      <h3 class="usa-card__heading">{{ include.card.card.title }}</h3>
     </header>
     <div class="usa-card__media">
       <div
-        class="usa-card__img height-card-lg {% unless include.card.href%}opacity-40{% endunless %}"
+        class="usa-card__img height-card-lg {% unless include.card.card.href%}opacity-40{% endunless %}"
       >
-        {% asset '{{ include.card.image }}' alt='{{ include.card.alt }}' style='object-position: center {{ include.card.position | default: "center" }}' %}
+        {% asset '{{ include.card.card.image }}' alt='{{ include.card.card.alt }}' style='object-position: center {{ include.card.card.position | default: "center" }}' %}
       </div>
     </div>
     <div class="usa-card__body">
       <p>
-        {{ include.card.description }}
+        {{ include.card.card.description }}
       </p>
     </div>
     <div class="usa-card__footer">
-      {% if include.card.href %}
+      {% if include.card.card.href %}
       <a
-        href="{{ include.card.href | relative_url }}"
-        aria-label="Learn more about {{include.card.title_alt | default:include.card.title}}"
+        href="{{ include.card.card.href | relative_url }}"
+        aria-label="Learn more about {{include.card.card.title_alt | default:include.card.card.title}}"
         >Learn more</a
       >
       {% endif %}

--- a/_includes/landing/understand.html
+++ b/_includes/landing/understand.html
@@ -17,7 +17,7 @@
             add more soon.
           </p>
           <ul class="usa-card-group">
-            {% for card in include.cards %}
+            {% for card in include.cards limit:3 %}
               {% include card.html card=card %}
             {% endfor %}
           </ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,7 +9,7 @@ layout: default
       {% include sidenav.html %}
     </div>
     {% endif %}
-    <div id="crt-page--content" class="tablet:grid-col-8">
+    <div id="crt-page--content" class="{% if page.sidenav %}tablet:grid-col-8{% endif %}">
       <h1 id="top">{{page.title}}</h1>
       <div class="crt-landing--separator_small"></div>
       {% if page.lead %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -42,7 +42,7 @@ history:
 
 {% include landing/alert.html alert=page.alert %}
 
-{% assign pages = (site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
+{% assign pages = site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
 {% assign cards = pages | concat: site.data.cards %}
 {% include landing/understand.html cards=cards %}
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -36,33 +36,15 @@ history:
     href: #
     text: Learn more ADA history
 
-cards:
-  - title: Introduction to the ADA
-    title_alt: the ADA
-    description: |-
-      Find out how the ADA is structured, and how it protects the rights of people with disabilities.
-    image: landing/intro_ada.jpg
-    alt: A teacher and a student sitting at a table signing to one another
-    href: /topics/intro-to-ada/
-  - title: Service animals
-    description: |-
-      Find out how the ADA defines a service animal, where they can go, and how they assist people with disabilities.
-    image: landing/service_animals.jpg
-    alt: A service animal helps a blind person down the stairs
-    href: /topics/service-animals/
-  - title: Parking
-    description: |-
-      <em>Coming soon!</em>
-    image: landing/parking.jpg
-    alt: A man in a wheelchair approaching a vehicle with his hand on the door handle
-    position: top
 ---
 
 {% include landing/hero.html hero=page.hero %}
 
 {% include landing/alert.html alert=page.alert %}
 
-{% include landing/understand.html cards=page.cards %}
+{% assign pages = (site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
+{% assign cards = pages | concat: site.data.cards %}
+{% include landing/understand.html cards=cards %}
 
 {% include landing/history.html history=page.history %}
 

--- a/_pages/topics/index.md
+++ b/_pages/topics/index.md
@@ -1,11 +1,12 @@
 ---
 permalink: /topics/
-title: What the ADA covers
+title: How the ADA Works
 sidenav: false
 show_card: false
 lead: |-
   Information for businesses, state and local governments, and people with disabilities.
 ---
+
 {% assign pages = site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
 
 {% assign cards = pages | concat: site.data.cards %}

--- a/_pages/topics/index.md
+++ b/_pages/topics/index.md
@@ -1,0 +1,19 @@
+---
+permalink: /topics/
+title: What the ADA covers
+sidenav: false
+show_card: false
+lead: |-
+  Information for businesses, state and local governments, and people with disabilities.
+---
+{% assign pages = (site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
+
+{% assign cards = pages | concat: site.data.cards %}
+
+<div class="grid-row grid-gap">
+  <ul class="usa-card-group">
+    {% for card in cards %}
+      {% include card.html card=card %}
+    {% endfor %}
+  </ul>
+</div>

--- a/_pages/topics/index.md
+++ b/_pages/topics/index.md
@@ -6,14 +6,14 @@ show_card: false
 lead: |-
   Information for businesses, state and local governments, and people with disabilities.
 ---
-{% assign pages = (site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
+{% assign pages = site.pages | where_exp:"item","item.permalink contains '/topics/' and item.name != 'index.md'" %}
 
 {% assign cards = pages | concat: site.data.cards %}
 
 <div class="grid-row grid-gap">
   <ul class="usa-card-group">
     {% for card in cards %}
-      {% include card.html card=card %}
+      {% include card.html card=card heading_level=2 %}
     {% endfor %}
   </ul>
 </div>

--- a/_pages/topics/intro-to-ada.md
+++ b/_pages/topics/intro-to-ada.md
@@ -4,6 +4,14 @@ description: The Americans with Disabilities Act (ADA) is a federal civil rights
 permalink: /topics/intro-to-ada/
 lead: |-
   The Americans with Disabilities Act (ADA) is a federal civil rights law that prohibits discrimination against people with disabilities in everyday activities. The ADA prohibits discrimination on the basis of disability just as other civil rights laws prohibit discrimination on the basis of race, color, sex, national origin, age, and religion. The ADA guarantees that people with disabilities have the same opportunities as everyone else to enjoy employment opportunities, purchase goods and services, and participate in state and local government programs.
+card:
+  title: Introduction to the ADA
+  title_alt: the ADA
+  description: |-
+    Find out how the ADA is structured, and how it protects the rights of people with disabilities.
+  image: landing/intro_ada.jpg
+  alt: A teacher and a student sitting at a table signing to one another
+  href: /topics/intro-to-ada/
 ---
 
 ## The ADA Protects People with Disabilities

--- a/_pages/topics/service-animals.md
+++ b/_pages/topics/service-animals.md
@@ -6,6 +6,13 @@ lead: |-
   The ADA explains what businesses and state/local governments must do to make sure that they do not discriminate against a member of the public with a disability who uses a service animal.
 
   Generally, businesses and non-profits that are open to the public as well as state/local governments must allow service animals to go most places where the public can go. This is true even if they have a "no pets" policy.
+card:
+  title: Service animals
+  description: |-
+    Find out how the ADA defines a service animal, where they can go, and how they assist people with disabilities.
+  image: landing/service_animals.jpg
+  alt: A service animal helps a blind person down the stairs
+  href: /topics/service-animals/
 ---
 
 ## About Service Animals


### PR DESCRIPTION
Fixes https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/221

Based on @austinhernandez's mockups, this adds a landing page to hold all of the future overlays. It also:

- Removes the drop down list for topics
- Moves the details shown on the card into the page's frontmatter so it can be reused
- Creates a "coming soon" data file to list overlays that are not already published
- Limits the number of overlays displayed on the homepage to 3

Preview:
<img width="1379" alt="Screen Shot 2021-06-30 at 3 15 37 PM" src="https://user-images.githubusercontent.com/1178494/124019091-9ca0ef00-d9b6-11eb-8424-85e549f18047.png">


