### PR TITLE
Disable search.gov typeahead

### DIFF
--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -40,7 +40,7 @@
       >Search {{site.title}}</label
     >
     <input
-      class="usa-input radius-left-lg usagov-search-autocomplete"
+      class="usa-input radius-left-lg"
       id="query"
       type="search"
       name="query"


### PR DESCRIPTION
Fixes https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/284

I was able to recreate this issue and I definitely feel like it's problematic. I brought it up to the search.gov team and they have it as an identified issue in their backlog.

> Definitely can see how this would be confusing on screen readers. We've thought about (and have an item in our backlog) changing it to "search suggestions" (ex. "2 search suggestions are available" or "No search suggestions") instead of results, which would hopefully be a bit clearer

Until that change is made, I believe the best move is to disable to typeahead functionality.