### PR TITLE
Changes 'ADA Topics' to 'Topics'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ google_site_verification: 34Ks265Uibpdda984RS0SxVABVZCdlVrdSp61pIdZQ8
 primary_navigation:
   - name: Home
     url: "/"
-  - name: ADA Topics
+  - name: Topics
     url: "/topics/"
   - name: File a Complaint
     url: "/file-a-complaint/"

--- a/_includes/landing/understand.html
+++ b/_includes/landing/understand.html
@@ -5,7 +5,7 @@
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-10">
         <h2 class="h1">
-          ADA Topics
+          Topics
         </h2>
         <div class="crt-landing--separator"></div>
         <p class="crt-landing--lead">

--- a/_pages/topics/index.md
+++ b/_pages/topics/index.md
@@ -1,6 +1,6 @@
 ---
 permalink: /topics/
-title: ADA Topics
+title: Topics
 sidenav: false
 lead: |-
   Information for businesses, state and local governments, and people with disabilities.


### PR DESCRIPTION
Changes nav text, page heading, and homepage section heading to `Topics` from `ADA Topics`.

The need for concision in the nav list made me think that `ADA Topics` is increasingly redundant. We developed that term as a working label for the overlay content, but now that we have a wordmark and more surrounding content, it seems _possibly_ unnecessary. I'm certainly willing to be persuaded otherwise, but I thought I would send it up to a pull request in the meantime to generate a preview.