### PR TITLE
Fix Federalist Preview link GitHub action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Comment Pull Request
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@main
         with:
           message: ":mag: [__Preview in Federalist__](https://federalist-1716bf9c-dd79-4d96-8285-6e56dc391b84.app.cloud.gov/preview/usdoj-crt/beta-ada/${{ github.head_ref }})"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update GitHub action to fix the automated addition of the Federalist preview link to the associated pull request.