### PR TITLE
Replace form 3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -133,7 +133,7 @@ exclude:
   - LICENSE.md
   - Dockerfile
   - docker-compose.yml
-  - complaint_form_sep2021.pdf
+  - downloads/**
 
 assets:
   autoprefixer:


### PR DESCRIPTION
I updated the config to exclude anything we put in the download directory.  We should be able to link to any pdf's or whatever we put in that folder now, without tripping up Pa11y.