### PR TITLE
Added babel transpiler v 0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '>= 2.6.6'
 
 gem "jekyll", "~> 4.0"
 gem "autoprefixer-rails"
+gem 'babel-transpiler', '~> 0.7.0'
 
 group :jekyll_plugins do
   gem 'jekyll-polyglot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.4.0)
       execjs
+    babel-source (5.8.35)
+    babel-transpiler (0.7.0)
+      babel-source (>= 4.0, < 6)
+      execjs (~> 2.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.8)
     em-websocket (0.5.2)
@@ -118,6 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
+  babel-transpiler (~> 0.7.0)
   jekyll (~> 4.0)
   jekyll-assets!
   jekyll-polyglot


### PR DESCRIPTION
[Babel Transpiler](https://rubygems.org/gems/babel-transpiler/versions/0.7.0) will allow developers to write safer, modern javascript in our code base while maintaining backwards compatibility with older browsers.

This change is in the Gemfile, which means that users will need to run `bundler install` after pulling in this change to make sure the software is installed locally. 

Babel Transpiler is run at build-time and converts all Javascript files that we denote with an .es6 extension to backwards compatible versions of Javascript.