### PR TITLE
Pagination button styling and Search page mobile styling.

### DIFF
--- a/_assets/css/custom/_pagination.scss
+++ b/_assets/css/custom/_pagination.scss
@@ -4,6 +4,10 @@
   pointer-events: none;
 }
 
+.usa-pagination__link[disabled] .usa-icon {
+  display: none;
+}
+
 .usa-pagination[hidden] {
   display: none !important;
 }
@@ -13,8 +17,13 @@
   color: #f0f0f0 !important;
 }
 
-.usa-pagination__button:hover {
+.usa-pagination__button:hover,
+.usa-pagination__button:focus,
+.usa-pagination__button.usa-current:hover,
+.usa-pagination__button.usa-current:focus {
   background-color: #2378C3 !important;
+  border: 1px solid transparent;
+  color: #f0f0f0 !important;
 }
 
 .usa-pagination__button.usa-current {
@@ -23,7 +32,12 @@
   border: 1px solid #2378C3;
 }
 
-.usa-pagination__item span {
+.usa-pagination__link-text:hover,
+.usa-pagination__link-text:focus {
+    color: #2378C3;
+}
+
+.usa-pagination__item span:not(.usa-pagination__link-text) {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/_assets/css/custom/_pagination.scss
+++ b/_assets/css/custom/_pagination.scss
@@ -7,3 +7,26 @@
 .usa-pagination[hidden] {
   display: none !important;
 }
+
+// Overrides the USWDS styling for the pagination buttons
+.usa-pagination__button {
+  color: #f0f0f0 !important;
+}
+
+.usa-pagination__button:hover {
+  background-color: #2378C3 !important;
+}
+
+.usa-pagination__button.usa-current {
+  background-color: #FFFFFF !important;
+  color: #2378C3 !important;
+  border: 1px solid #2378C3;
+}
+
+.usa-pagination__item span {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #000;
+}

--- a/_assets/css/custom/_pagination.scss
+++ b/_assets/css/custom/_pagination.scss
@@ -1,3 +1,7 @@
+.usa-pagination {
+  align-items: center;
+}
+
 .usa-pagination__link[disabled] {
   color: color($theme-color-base);
   opacity: 1 !important;

--- a/_assets/js/templates/pagination/ellipsisTemplate.js
+++ b/_assets/js/templates/pagination/ellipsisTemplate.js
@@ -1,9 +1,9 @@
 function ellipsis() {
   return `<li
     class="usa-pagination__item usa-pagination__overflow display-none tablet:display-block"
-    role="none presentation"
+    role="none"
     tabindex='-1'
   >
-    <span> … </span>
+    <span class="text-bold"> … </span>
   </li>`;
 };

--- a/_assets/js/templates/pagination/paginationButtonTemplate.js
+++ b/_assets/js/templates/pagination/paginationButtonTemplate.js
@@ -18,10 +18,10 @@ function paginationButton(offsetVal, index, resultsArr) {
   return `<li class="usa-pagination__item usa-pagination__page-no display-none tablet:display-block">
       <a
         href="?${offsetUtils.setOffsetParam(offsetVal)}"
-        class="usa-pagination__button"
+        class="usa-pagination__button bg-primary-darker"
         aria-label="${ariaLabel}""
         aria-current=${ariaCurrent}
-        data-offset= ${offsetVal}
+        data-offset=${offsetVal}
       >
         ${index + 1}
       </a>

--- a/_assets/js/templates/pagination/paginationTemplate.js
+++ b/_assets/js/templates/pagination/paginationTemplate.js
@@ -5,9 +5,8 @@
 //= require ./paginationButtonTemplate.js
 //= require ./pageNumber.js
 //= require ../../utils/paginationLogic/index.js
-
-const paginationTemplate = (resultsArr, urlParams) => {
-  const offsetInt = parseInt(urlParams.get("offset"));
+var paginationTemplate = function(resultsArr, urlParams) {
+  var offsetInt = parseInt(urlParams.get("offset"));
   pageNumber(resultsArr);
   if (resultsArr.length <= 7) {
     return `

--- a/_assets/js/templates/search/noResultsTemplate.js
+++ b/_assets/js/templates/search/noResultsTemplate.js
@@ -1,3 +1,3 @@
 function noResults() {
-    return `<li class="h4" style="list-style: none">No results found</li>`
+    return `<li role="status" class="h4" style="list-style: none">No results found</li>`
 }

--- a/_assets/js/templates/search/searchResultsTemplate.js
+++ b/_assets/js/templates/search/searchResultsTemplate.js
@@ -4,7 +4,7 @@ function searchResultsTemplate(content) {
         <b class="title"><a href="${content.url}">${content.title
           .replace(/\uE000/g, '<span class="bg-yellow">')
           .replace(/\uE001/g, "</span>")}</a></b>
-      <div class="text-base"> ${content.url} </div>
+      <div class="text-base content-url"> ${content.url} </div>
       <div> ${content.snippet
           .replace(/\uE000/g, '<span class="bg-yellow">')
           .replace(/\uE001/g, "</span>")} </div>

--- a/_assets/js/templates/search/totalResultsTemplate.js
+++ b/_assets/js/templates/search/totalResultsTemplate.js
@@ -1,3 +1,3 @@
 function totalResults(resultsTotal) {
-    return `<div role="status" class="text-base">${resultsTotal} results found</div>`
+    return `<div role="status" class="text-black">${resultsTotal} results found</div>`
 }

--- a/_assets/js/utils/paginationLogic/index.js
+++ b/_assets/js/utils/paginationLogic/index.js
@@ -5,17 +5,17 @@ var paginationLogic = (function () {
   var firstPage = function(offsetArrayVal, offsetParamVal) {
     return (
       offsetParamVal === 0 &&
-      (offsetArrayVal === offsetParamVal + 20 ||
-        offsetArrayVal === offsetParamVal + 40 ||
-        offsetArrayVal === offsetParamVal + 60)
+      (offsetArrayVal === offsetParamVal + NUMBER_OF_RESULTS ||
+        offsetArrayVal === offsetParamVal + (NUMBER_OF_RESULTS + 20) ||
+        offsetArrayVal === offsetParamVal + (NUMBER_OF_RESULTS + 40))
     );
   };
   // If you are viewing the second page of results, display the second, third and fourth pagination buttons.
   var secondPageEtc = function(offsetArrayVal, offsetParamVal) {
-    return offsetParamVal === 20 &&
+    return offsetParamVal === NUMBER_OF_RESULTS &&
     (offsetArrayVal === offsetParamVal ||
-      offsetArrayVal === offsetParamVal + 20 ||
-      offsetArrayVal === offsetParamVal + 40)
+      offsetArrayVal === offsetParamVal + NUMBER_OF_RESULTS ||
+      offsetArrayVal === offsetParamVal + (NUMBER_OF_RESULTS + 20))
   }
   // If you are viewing any page page after page 1 or 2, or before the second to last and last pages, display
   // the pagination buttons for the previous page, current page and next page of results.
@@ -23,24 +23,24 @@ var paginationLogic = (function () {
     return (
       urlParams.get("offset") &&
       (offsetArrayVal === offsetParamVal ||
-        offsetArrayVal === offsetParamVal - 20 ||
-        offsetArrayVal === offsetParamVal + 20)
+        offsetArrayVal === offsetParamVal - NUMBER_OF_RESULTS ||
+        offsetArrayVal === offsetParamVal + NUMBER_OF_RESULTS)
     );
   };
   // If you are viewing the second-to-last page of results, display the second-to-last, third-to-last and fourth-to-last pagination buttons.
   var secondToLastPage = function(offsetArrayVal, offsetParamVal, resultsArray) {
     return offsetParamVal === resultsArray[resultsArray.length - 2] &&
     (offsetArrayVal === offsetParamVal ||
-      offsetArrayVal === offsetParamVal - 20 ||
-      offsetArrayVal === offsetParamVal - 40)
+      offsetArrayVal === offsetParamVal - NUMBER_OF_RESULTS ||
+      offsetArrayVal === offsetParamVal - (NUMBER_OF_RESULTS + 20))
   }
   // If you are viewing the last page of results, display the last four pagination buttons.
   var lastPage = function(offsetArrayVal, offsetParamVal, resultsArray) {
     return (
       offsetParamVal === resultsArray[resultsArray.length - 1] &&
-      (offsetArrayVal === offsetParamVal - 20 ||
-        offsetArrayVal === offsetParamVal - 40 ||
-        offsetArrayVal === offsetParamVal - 60)
+      (offsetArrayVal === offsetParamVal - NUMBER_OF_RESULTS ||
+        offsetArrayVal === offsetParamVal - (NUMBER_OF_RESULTS + 20) ||
+        offsetArrayVal === offsetParamVal - (NUMBER_OF_RESULTS + 40))
     );
   };
   // Export public methods:

--- a/_assets/js/utils/renderSearchPage.js
+++ b/_assets/js/utils/renderSearchPage.js
@@ -3,6 +3,7 @@
 //= require ./applyFocusStyling.js
 //= require ./createRange.js
 //= require ./constants.js
+//= require ./wrapUrls.js
 //= require ../templates/pagination/paginationTemplate.js
 //= require ../templates/search/textBestBetsTemplate.js
 //= require ../templates/search/searchResultsTemplate.js
@@ -89,5 +90,10 @@ function renderSearchPage(searchResults, urlParams, numberOfResults) {
       "afterend",
       totalResults(webTotalResults)
     );
+    var urlsToWrap = document.querySelectorAll(".content-url");
+    Array.prototype.forEach.call(urlsToWrap, function(url) {
+      var wrapped = wrapUrls(url.innerHTML);
+      return (url.innerHTML = wrapped);
+    });
   }
 };

--- a/_assets/js/utils/renderSearchPage.js
+++ b/_assets/js/utils/renderSearchPage.js
@@ -84,7 +84,7 @@ function renderSearchPage(searchResults, urlParams, numberOfResults) {
       false
     );
   } else {
-    var target = document.querySelector("#top");
+    var target = document.querySelector(".crt-landing--separator_small");
     target.insertAdjacentHTML(
       "afterend",
       totalResults(webTotalResults)

--- a/_assets/js/utils/wrapUrls.js
+++ b/_assets/js/utils/wrapUrls.js
@@ -1,0 +1,23 @@
+// Insert word break opportunities into a URL following the Chicago Manual of Style
+// @param {string} url A URL to format
+// @return {string} A formatted URL
+// @see {@link https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/psec018.html Chicago Manual of Style 14.18}
+// @see Turabian 2018, 20.4.2
+// Adapted from: https://css-tricks.com/better-line-breaks-for-long-urls/
+
+function wrapUrls(url) {
+  // Split the URL into an array to distingish double slashes from single slashes
+  var doubleSlash = url.split("//");
+  // Format the strings on either side of double slashes separately
+  var formatted = doubleSlash.map(function(str) {
+    return str
+          .replace(/(?<after>:)/giu, "$1<wbr>")
+          // Before a single slash, tilde, period, comma, hyphen, underline, question mark, number sign, or percent symbol
+           .replace(/(?<before>[/~.,_?#%-])/giu, "<wbr>$1")
+           // Before and after an equals sign or ampersand
+           .replace(/(?<equals>=)/giu, "<wbr>$1<wbr>")
+           .replace(/(?<ampersand>&amp;)/giu, "<wbr>&<wbr>")
+           // Reconnect the strings with word break opportunities after double slashes
+    }).join("//<wbr>");
+  return formatted;
+};

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@ layout: default
       {% endif %}
     </div>
     {% endif %}
-    <div id="crt-page--content" class="{% if page.sidenav %}tablet:grid-col-8{% endif %}">
+    <div id="crt-page--content" class="mobile-lg:grid-col {% if page.sidenav %}tablet:grid-col-8{% endif %}">
       <div aria-hidden="true" id="crt-page--content-target"></div>
       {% if page.disclaimer %}
       {% include alert.html title="This is a test site. Do not rely on the information provided." text="This webpage is a prototype meant for user research. It has not undergone final review for legal accuracy and is not intended to provide legal guidance." %}


### PR DESCRIPTION
Resolves two issues: https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/363 and https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/364

Styling/Markup Changes:
1. Added hover/focus state changes to pagination buttons and next/previous links. Changes can be seen in _pagination.scss
2. Bolded the ellipses and cleaned up aria roles for them. See ellipsisTemplate.js
3. Added a darker background to the pagination buttons via paginationButtonTemplate.js
4. Added role=status to noResultsTemplate.js this mirrors the aria labels in the total number of results found template. 
5. Added a class to totalResultsTemplate.js to make the text black.
6. Changed the target variable in renderSearchPage.js to .crt-landing--separator_small so that the total results text will display below the cute little yellow line. 
7. Added a mobile:grid-col class to the page.html file to get the main content to fit on mobile screens.

JS Changes:
1. Cleaned up JS in paginationTemplate.js to get rid of some pesky consts
2. Refactored the code in paginationLogic/index.js to be more DRY. Pulls in the NUMBER_OF_RESULTS constant to make it easier to update the code depending on the number of results per page we want to display.
3. Added wrapUrls.js script which grabs the urls under the titles on the search page and dynamically adds <wbr> (word breaks) at areas specified by the Chicago Manual of Style. This helps with mobile styling. 

To Test:
1. Open federalist link
2. Confirm that the search page's styling matches this screen shot:
<img width="617" alt="mobilesearchstyling" src="https://user-images.githubusercontent.com/14644234/149403355-6fff2f64-4370-45c7-99e1-086f891fc59a.png">
And that the buttons match this style guide:
<img width="616" alt="nextpage" src="https://user-images.githubusercontent.com/14644234/149403542-5616797f-9745-45d6-81fd-53f0e2d547cb.png">
3. Shrink the page, confirm that nothing overflows the width of the screen.
4. Confirm that the urls below each search result title break before punctuation and that none overflow width of sceen. 