### PR TITLE
Prevent H1 text overflow on tablet devices

### DIFF
--- a/_includes/landing/hero.html
+++ b/_includes/landing/hero.html
@@ -8,11 +8,12 @@
   class="height-auto width-full tablet:display-none" %}
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="tablet:grid-col-8">
+      <div class="tablet:grid-col-6 desktop:grid-col-8">
         <h1>
           {{ include.hero.heading }}
         </h1>
       </div>
+      <div aria-hidden="true" class="tablet:grid-col-2 desktop:display:none"></div>
       <div class="tablet:grid-col-6">
         <div class="crt-landing--separator"></div>
         <p class="crt-landing--largetext">

--- a/_includes/landing/hero.html
+++ b/_includes/landing/hero.html
@@ -13,7 +13,7 @@
           {{ include.hero.heading }}
         </h1>
       </div>
-      <div aria-hidden="true" class="tablet:grid-col-2 desktop:display:none"></div>
+      <div aria-hidden="true" class="tablet:grid-col-2 desktop:display-none"></div>
       <div class="tablet:grid-col-6">
         <div class="crt-landing--separator"></div>
         <p class="crt-landing--largetext">


### PR DESCRIPTION
Closes [https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/374](https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/374)

The Problem:
<img width="802" alt="Screen Shot 2022-01-14 at 11 29 19 AM" src="https://user-images.githubusercontent.com/14644234/149550628-caa61250-0af1-431b-b1ed-ca7ec8d22333.png">

The Solution:
<img width="801" alt="Screen Shot 2022-01-14 at 11 29 52 AM" src="https://user-images.githubusercontent.com/14644234/149550647-25fc542f-0aae-4a9a-89aa-83bc37b1ce97.png">

Styling/Markup changes:
1. On the div containing the H1, added 2 classes: tablet-grid-col-6, and desktop-grid-col-8. This will shrink the width of the H1 on tablet devices and will preserve the current width on desktop devices.
2. Added a spacer div below the H1 containing div. Set the aria-hidden attribute to "true" so it is ignored by assistive technology. Added two classes: tablet-grid-col-2 and desktop:display-none. These classes mean that the layout between the H1 and paragraph text is preserved, and that this div is not displayed on desktop devices. 

To test: 
1. Open Federalist link
2. Confirm that new div is not picked up when tabbing through the page
3. Confirm that the layout on tablet and desktop is the same
4. Confirm that the H1 text overflow on the image is minimal or non-existent for tablet sized devices.
5. Confirm that mobile and desktop layouts are unaffected,
