### PR TITLE
Added production jekyll environment to build script.

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,7 +6,7 @@
 ></script>
 {% endif %}
 
-{% if site.ga.ua %}
+{% if site.ga.ua and jekyll.environment=="production" %}
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga.ua }}"></script>
 <script>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "federalist-uswds-jekyll",
   "version": "1.3.0",
   "scripts": {
-    "build": "bundle exec jekyll build",
+    "build": "bundle exec JEKYLL_ENV=production jekyll build",
     "clean": "bundle exec jekyll clean",
     "start": "bundle exec jekyll serve --livereload",
     "test:a11y": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml"


### PR DESCRIPTION
Changes:
1. Added `JEKYLL_ENV=production` to our build script in `package.json`.
2. I did not add a value of 'development' anywhere because [Jekyll assumes that value for the environment if none is specified](https://jekyllrb.com/docs/configuration/environments/)
3. The goal here is to prevent Google Analytics from running when on localhost, so in `scripts.html` I've added an and clause to the if statement that injects the GA script: `if site.ga.ua and jekyll.environment=="production"`