### PR TITLE
USWDS upgrade to 2.12.0

### DIFF
--- a/_assets/css/_uswds-theme-components.scss
+++ b/_assets/css/_uswds-theme-components.scss
@@ -85,11 +85,9 @@ $theme-input-max-width: "mobile-lg";
 $theme-input-select-border-width: 2px;
 $theme-input-select-size: 2.5;
 $theme-input-state-border-width: 0.5;
-$theme-input-tile-background-color-selected: "primary-lighter";
 $theme-input-tile-border-radius: "md";
 $theme-input-tile-border-width: 2px;
-$theme-input-tile-border-color: "base-lighter";
-$theme-input-tile-border-color-selected: "primary-light";
+
 
 // Header
 $theme-header-font-family: "ui";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "anchor-js": "^4.3.1",
         "gumshoejs": "^5.1.2",
-        "uswds": "^2.11.1"
+        "uswds": "^2.12.0"
       },
       "devDependencies": {
         "pa11y-ci": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
     "build": "bundle exec JEKYLL_ENV=production jekyll build",
     "clean": "bundle exec jekyll clean",
     "start": "bundle exec jekyll serve --livereload",
-    "test:a11y": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml"
+    "test:a11y": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml",
+    "test:landing": "pa11y-ci --config ./pa11y_scripts/.ada-landing.json"
   },
   "dependencies": {
     "anchor-js": "^4.3.1",
     "gumshoejs": "^5.1.2",
-    "uswds": "^2.11.1"
+    "uswds": "^2.12.0"
   },
   "devDependencies": {
     "pa11y-ci": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "build": "bundle exec JEKYLL_ENV=production jekyll build",
     "clean": "bundle exec jekyll clean",
     "start": "bundle exec jekyll serve --livereload",
-    "test:a11y": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml",
-    "test:landing": "pa11y-ci --config ./pa11y_scripts/.ada-landing.json"
+    "test:a11y": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml"
   },
   "dependencies": {
     "anchor-js": "^4.3.1",


### PR DESCRIPTION
Changes:
1. package.json - updated USWDS to version 2.12.0
2. package-lock.json
3. Removed "$theme-input-tile-background-color-selected", "$theme-input-tile-border-color" and "$theme-input-tile-border-color-selected" from `_uswds-theme-components.scss` as they are now calculated automatically. 
4. See release manifest here: https://github.com/uswds/uswds/releases/tag/v2.12.0