### PR TITLE
Added styling rules to provide a hover and focus state to the print button

### DIFF
--- a/_assets/css/custom/_buttons.scss
+++ b/_assets/css/custom/_buttons.scss
@@ -10,15 +10,24 @@
   }
 }
 
+#crt-page--printbutton {
+  background-color: color($theme-color-primary-darker);
+  &:hover {
+    background: color($theme-link-hover-color);
+  }
+  &:focus {
+    background: color($theme-link-hover-color);
+  }
+}
+
 @media screen and (min-width: 0px) {
   #crt-page--printbutton--wrapper {
     display: none;
-  }  
+  }
 }
 
 @media screen and (min-width: 1024px) {
   #crt-page--printbutton--wrapper {
     display: block;
-  }  
+  }
 }
-


### PR DESCRIPTION
Problem:
The Print button doesn't change color when hovered with a mouse or when receiving keyboard focus. 

Changes:
1. Added rules to _buttons.scss for the #crt-page--printbutton. 
- Assigned a background color
- Assigned a hover state color that is in line with our style guide
- Assigned a focus state color that is in line with our style guide

Closes https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/392