### PR TITLE
Updated to version 2.12.2. Fixed missing search icon.

### DIFF
--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -48,6 +48,7 @@
     />
     <button class="usa-button radius-right-lg" type="submit">
       {% asset img/usa-icons-bg/search--white.svg class="desktop:display-none" alt="{{site.data[lang]['i18n'].aria.search}}" %}
+      <span class="usa-sr-only">Search Beta.ADA.gov</span>
     </button>
   </form>
   {% endif %}

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -1,3 +1,5 @@
+{% assign lang = page.lang %}
+{% if lang==nil %}{% assign lang="en" %}{% endif %}
 {% if include.searchgov %}
 <script>
   //<![CDATA[
@@ -45,7 +47,7 @@
       autocomplete="off"
     />
     <button class="usa-button radius-right-lg" type="submit">
-      <span class="usa-sr-only">{{site.data[lang]["i18n"].aria.search}}</span>
+      {% asset img/usa-icons-bg/search--white.svg class="desktop:display-none" alt="{{site.data[lang]['i18n'].aria.search}}" %}
     </button>
   </form>
   {% endif %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "anchor-js": "^4.3.1",
         "gumshoejs": "^5.1.2",
-        "uswds": "^2.12.1"
+        "uswds": "^2.12.2"
       },
       "devDependencies": {
         "pa11y-ci": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "anchor-js": "^4.3.1",
     "gumshoejs": "^5.1.2",
-    "uswds": "^2.12.1"
+    "uswds": "^2.12.2"
   },
   "devDependencies": {
     "pa11y-ci": "^3.0.1"


### PR DESCRIPTION
Changes:
1. Package.json - updated USWDS to version 2.12.2
2. The search icon is missing on screen sizes < desktop. Added markup recommended from USWDS version 2.13 to fix. That markup was added to the forms.html file.
<img width="150" alt="Screen Shot 2022-02-23 at 12 03 18 PM" src="https://user-images.githubusercontent.com/14644234/155369234-e0442653-f8ae-44b6-b5f7-169a576bd049.png">

