### PR TITLE
Covid banner and page title changes

### DIFF
--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -13,7 +13,7 @@
         <a
           class="text-no-underline hover:text-ink hover:text-underline"
           href="{{ post.url | relative_url }}"
-          >{% if lang=="en" %}{{ post.title }}{% elsif lang=="es" %}{{post.title_es}}{% endif %}</a
+          >{% if lang=="en" %}{{ post.notice_text }}{% elsif lang=="es" %}{{post.notice_text_es}}{% endif %}</a
         >
         {% endfor %}
       </div>

--- a/_pages/notices/_posts/2021-08-25-covid-qa.md
+++ b/_pages/notices/_posts/2021-08-25-covid-qa.md
@@ -1,8 +1,9 @@
 ---
 
-title:  COVID-19 and the Americans with Disabilities Act&mdash;recently updated with information about streateries and medical setting visitor policies
-title_es: El COVID-19 y la ley de Estadounidenses con Discapacidades&mdash; actualizado hace poco con información sobre políticas para restaurantes en la calle y visitantes a entornos médicos
-
+title:  COVID-19 and the Americans with Disabilities Act
+title_es: El COVID-19 y la ley de Estadounidenses con Discapacidades
+notice_text: COVID-19 and the Americans with Disabilities Act &mdash;view information about streateries and medical setting visitor policies
+notice_text_es: El COVID-19 y la ley de Estadounidenses con Discapacidades &mdash; actualizado hace poco con información sobre políticas para restaurantes en la calle y visitantes a entornos médicos
 
 ---
 
@@ -23,12 +24,12 @@ title_es: El COVID-19 y la ley de Estadounidenses con Discapacidades&mdash; actu
 {% endlist_item %}
 {% endlist %}
 
-The [rules for admitting service animals]( {{'/topics/service-animals'| relative_url}}) are the same even during the pandemic.  
+The [rules for admitting service animals]( {{'/topics/service-animals'| relative_url}}) are the same even during the pandemic.
 
 A service animal is a dog that has been individually trained to do work or perform tasks for a person with a disability. The tasks must be directly related to the person’s disability.
 
 A business or a state/local government generally must allow a service animal to
-accompany a person with a disability into any area where the public is allowed to go. A service animal cannot be excluded just because staff can provide the same services.  
+accompany a person with a disability into any area where the public is allowed to go. A service animal cannot be excluded just because staff can provide the same services.
 
 [According to the CDC](https://www.cdc.gov/coronavirus/2019-ncov/daily-life-coping/animals.html), the risk of animals spreading COVID-19 to people is considered to be low.
 
@@ -82,7 +83,7 @@ An individualized assessment is needed to determine whether a person’s long CO
 
 For more information, see the Department’s [Guidance on &quot;Long COVID&quot; as a Disability Under the ADA, Section 504, and Section 1557](https://www.ada.gov/long_covid_joint_guidance.pdf).
 
-{% endcollapsible %}  
+{% endcollapsible %}
 
 {% collapsible %}
 ## Are there resources available that help explain my rights as an employee with a disability during the COVID-19 pandemic?
@@ -98,63 +99,63 @@ For more information about your rights, visit the EEOC website at [www.eeoc.gov
 {% endcollapsible %}
 
 {% collapsible %}
-## Can a hospital or medical facility exclude all “visitors” even where, due to a patient’s disability, the patient needs help from a family member, companion, or aide in order to equally access care?  
+## Can a hospital or medical facility exclude all “visitors” even where, due to a patient’s disability, the patient needs help from a family member, companion, or aide in order to equally access care?
 
 {% list cancel %}
 {% list_item %}No.
 {% endlist_item %}
-{% endlist %}  
+{% endlist %}
 
-To limit the spread of COVID-19, medical providers have changed many of their policies, including restricting non-patients from entering health care facilities.  However, where these policies do not account for the needs of people with disabilities, they may result in unequal care and violate the ADA.  For instance, where a patient’s disability prevents them from providing their medical history or understanding medical decisions or directions, the medical provider should explore whether a modification to its visitor policy may be safely carried out.  
+To limit the spread of COVID-19, medical providers have changed many of their policies, including restricting non-patients from entering health care facilities.  However, where these policies do not account for the needs of people with disabilities, they may result in unequal care and violate the ADA.  For instance, where a patient’s disability prevents them from providing their medical history or understanding medical decisions or directions, the medical provider should explore whether a modification to its visitor policy may be safely carried out.
 
-Several important limitations apply.  Not every person with a disability needs someone with them in order to equally access medical care.  For those who do not, excluding a companion does not violate the ADA.  Also, the ADA recognizes that protecting the rights of individuals with disabilities may need to be balanced with other safety concerns.  For instance, the ADA allows health care providers to impose “legitimate safety requirements” that are necessary for safe operation.  But a blanket ban on all non-patients in all care settings does not fall into this narrow category—even in the midst of COVID-19.  Where the exclusion is necessary from a public health perspective, medical providers should think creatively about how to best serve the needs of the patient with a disability.  
+Several important limitations apply.  Not every person with a disability needs someone with them in order to equally access medical care.  For those who do not, excluding a companion does not violate the ADA.  Also, the ADA recognizes that protecting the rights of individuals with disabilities may need to be balanced with other safety concerns.  For instance, the ADA allows health care providers to impose “legitimate safety requirements” that are necessary for safe operation.  But a blanket ban on all non-patients in all care settings does not fall into this narrow category—even in the midst of COVID-19.  Where the exclusion is necessary from a public health perspective, medical providers should think creatively about how to best serve the needs of the patient with a disability.
 
 EXAMPLE: An adult with Down Syndrome who cannot speak has severe chest pain and goes to the hospital with his parent.  Due to COVID-era restrictions on visitors, the hospital stops the patient’s parent from joining him in the hospital’s Emergency Department, resulting in delayed treatment and critical medical history not being communicated to the medical team.  This is a violation of the ADA.
 
-EXAMPLE: A person with severely limited mobility is admitted to a hospital for appendicitis. This patient would like his adult daughter to accompany him during his hospital stay.  In this case, the ADA would not require the hospital to modify its COVID-era “visitor policy” to permit the daughter to enter because the daughter’s presence plays no special role in ensuring that the patient receives equal access to care.  
+EXAMPLE: A person with severely limited mobility is admitted to a hospital for appendicitis. This patient would like his adult daughter to accompany him during his hospital stay.  In this case, the ADA would not require the hospital to modify its COVID-era “visitor policy” to permit the daughter to enter because the daughter’s presence plays no special role in ensuring that the patient receives equal access to care.
 
-EXAMPLE: The spouse of a patient who is being treated for a traumatic brain injury tested positive for COVID-19 two days ago.  The medical office providing rehabilitation services is justified under the ADA in excluding the spouse from entering the facility.  However, the provider should work with the spouse, including through the use of technology, to allow the spouse’s remote participation to ensure that the patient receives equal access to care.  
+EXAMPLE: The spouse of a patient who is being treated for a traumatic brain injury tested positive for COVID-19 two days ago.  The medical office providing rehabilitation services is justified under the ADA in excluding the spouse from entering the facility.  However, the provider should work with the spouse, including through the use of technology, to allow the spouse’s remote participation to ensure that the patient receives equal access to care.
 
 {% endcollapsible %}
 
 {% collapsible %}
-## Does the ADA apply to outdoor restaurants (sometimes called “streateries”) or other outdoor retail spaces that have popped up since COVID-19?  
+## Does the ADA apply to outdoor restaurants (sometimes called “streateries”) or other outdoor retail spaces that have popped up since COVID-19?
 
 {% list check_circle %}
 {% list_item %}Yes.
 {% endlist_item %}
 {% endlist %}
 
-Just as the ADA requires businesses to make indoor restaurants or retail shops accessible to people with disabilities, it requires businesses to make outdoor spaces for dining and retail accessible as well. Local governments must also make sure that their programs and activities—such as providing and maintaining curb ramps, accessible routes on sidewalks, and accessible street parking—continue to comply with the ADA even though “business” has moved outside.  
+Just as the ADA requires businesses to make indoor restaurants or retail shops accessible to people with disabilities, it requires businesses to make outdoor spaces for dining and retail accessible as well. Local governments must also make sure that their programs and activities—such as providing and maintaining curb ramps, accessible routes on sidewalks, and accessible street parking—continue to comply with the ADA even though “business” has moved outside.
 
-For a restaurant, this could mean providing an accessible route from the accessible parking and the accessible sidewalk to the outdoor dining area’s accessible seating. An accessible route is one that is free of obstacles—such as sandwich boards, heaters, planters, chairs, or tables—that would make it difficult or impossible for a person with a mobility disability to access the business. For an outdoor retail space, this could mean providing an accessible route from the accessible parking and the accessible sidewalk to and throughout the retail space and providing an accessible check out area.  
+For a restaurant, this could mean providing an accessible route from the accessible parking and the accessible sidewalk to the outdoor dining area’s accessible seating. An accessible route is one that is free of obstacles—such as sandwich boards, heaters, planters, chairs, or tables—that would make it difficult or impossible for a person with a mobility disability to access the business. For an outdoor retail space, this could mean providing an accessible route from the accessible parking and the accessible sidewalk to and throughout the retail space and providing an accessible check out area.
 
-Additionally, this could mean removing objects that stick out or protrude into the sidewalks that people use to get to and through these spaces. Many objects, such as umbrellas, canopies, tables, tree branches, or displays are at heights that cannot be detected by someone using a cane to assist with their vision disability. These protruding objects make the sidewalk dangerous to people who are blind or have low vision. To eliminate hazards, a restaurant might need to contact their local government to trim trees along the sidewalks that are now within or part of an outdoor dining or retail space.  
+Additionally, this could mean removing objects that stick out or protrude into the sidewalks that people use to get to and through these spaces. Many objects, such as umbrellas, canopies, tables, tree branches, or displays are at heights that cannot be detected by someone using a cane to assist with their vision disability. These protruding objects make the sidewalk dangerous to people who are blind or have low vision. To eliminate hazards, a restaurant might need to contact their local government to trim trees along the sidewalks that are now within or part of an outdoor dining or retail space.
 
-For local governments, complying with the ADA could also mean making sure, during the permit process as well as on an everyday basis, that streateries or outdoor retail do not block curb ramps, sidewalks, or accessible street parking so that persons with disabilities may continue to use them.  
+For local governments, complying with the ADA could also mean making sure, during the permit process as well as on an everyday basis, that streateries or outdoor retail do not block curb ramps, sidewalks, or accessible street parking so that persons with disabilities may continue to use them.
 
-EXAMPLE: A person who uses a wheelchair cannot continue along the accessible sidewalk where a streatery is located because outdoor diners, and their tables and chairs, are spread across the sidewalk, blocking the accessible route.  The restaurant must move the tables, chairs, and other items blocking the sidewalk to restore the accessible route for people with disabilities and then maintain that clear route. The local government may also have a responsibility to make sure that the accessible route is clear because it provides and maintains the sidewalks.  
+EXAMPLE: A person who uses a wheelchair cannot continue along the accessible sidewalk where a streatery is located because outdoor diners, and their tables and chairs, are spread across the sidewalk, blocking the accessible route.  The restaurant must move the tables, chairs, and other items blocking the sidewalk to restore the accessible route for people with disabilities and then maintain that clear route. The local government may also have a responsibility to make sure that the accessible route is clear because it provides and maintains the sidewalks.
 
-EXAMPLE: A person who is blind looks forward to dining at a streatery but once there runs into the edge of a table umbrella and is injured because the umbrella is too low. The restaurant must raise the umbrellas so that the protruding parts of the umbrella—the edges—are at a height that complies with the ADA and pose less risk to patrons with vision disabilities.  
+EXAMPLE: A person who is blind looks forward to dining at a streatery but once there runs into the edge of a table umbrella and is injured because the umbrella is too low. The restaurant must raise the umbrellas so that the protruding parts of the umbrella—the edges—are at a height that complies with the ADA and pose less risk to patrons with vision disabilities.
 
-EXAMPLE: A store sets up a curbside pickup booth, blocking the designated accessible parking space. The store must move the booth to another location so that the accessible parking space and related access aisle can be used by people with disabilities.  
+EXAMPLE: A store sets up a curbside pickup booth, blocking the designated accessible parking space. The store must move the booth to another location so that the accessible parking space and related access aisle can be used by people with disabilities.
 
 {% endcollapsible %}
 {% endaccordion %}
 
-## Learn more about the Civil Rights Division’s disability response to Coronavirus  
+## Learn more about the Civil Rights Division’s disability response to Coronavirus
 
 [Departments of Justice and Education Issue Guidance on Supporting and Protecting Rights of Students with Mental Health Disabilities in Era of COVID-19](https://www.ada.gov/students_self-harm_fact_sheet.pdf)  (10/13/21)
 
 [Guidance on When &quot;Long COVID&quot; May Be a Disability Under the ADA, Section 504, and Section 1557](https://www.ada.gov/long_covid_joint_guidance.pdf) (7/26/21)
 
-[Leading a Coordinated Civil Rights Response to Coronavirus (COVID-19)](https://www.justice.gov/opa/pr/statement-principal-deputy-assistant-attorney-general-civil-rights-leading-coordinated-civil)  
+[Leading a Coordinated Civil Rights Response to Coronavirus (COVID-19)](https://www.justice.gov/opa/pr/statement-principal-deputy-assistant-attorney-general-civil-rights-leading-coordinated-civil)
 Statement by Principal Deputy Assistant Attorney General Pamela S. Karlan (4/2/21)
 
-[The Department of Justice Warns of Inaccurate Flyers and Postings Regarding the Use of Face Masks and the Americans with Disabilities Act](https://www.justice.gov/opa/pr/department-justice-warns-inaccurate-flyers-and-postings-regarding-use-face-masks-and)  
+[The Department of Justice Warns of Inaccurate Flyers and Postings Regarding the Use of Face Masks and the Americans with Disabilities Act](https://www.justice.gov/opa/pr/department-justice-warns-inaccurate-flyers-and-postings-regarding-use-face-masks-and)
 Press Release (6/30/20)
 
-[Protecting Civil Rights While Responding to the Coronavirus Disease 2019 (COVID-19)](https://www.ada.gov/aag_covid_statement.pdf)  
+[Protecting Civil Rights While Responding to the Coronavirus Disease 2019 (COVID-19)](https://www.ada.gov/aag_covid_statement.pdf)
 Statement by Assistant Attorney General Eric S. Dreiband (4/28/20)
 
 [ADA Emergency Management Resources](https://www.ada.gov/emerg_prep.html)


### PR DESCRIPTION
Changes:
1. Added new frontmatter fields to the COVID QA page. `notice_text` and `notice_text_es`. Previously we referred to the page title, but since that is no longer appropriate I created a new field to reference in both the English and Spanish translations. Note: Spanish translation text will be updated asap.
2. In `notice.html` The anchor tag now references the two new fields mentioned above.