### PR TITLE
Translate Body Copy only

### DIFF
--- a/_includes/banner-beta.html
+++ b/_includes/banner-beta.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <section class="usa-banner crt-banner--beta margin-y-1" aria-label="{{site.data[lang]['i18n'].aria.banner_beta}}">

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <section class="usa-banner" aria-label="{{site.data[lang]['i18n'].aria.banner_official}}">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <footer class="usa-footer usa-footer--slim">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,12 +14,12 @@
         {% include logo.html %}
       </div>
       {% include phone.html %}
-      <button class="usa-menu-btn">{{site.data[lang]["i18n"].links.menu}}</button>
+      <button class="usa-menu-btn">{{site.data["en"]["i18n"].links.menu}}</button>
     </div>
-    <nav aria-label="{{site.data[lang]['i18n'].aria.primary_navigation}}" class="usa-nav">
+    <nav aria-label="{{site.data['en']['i18n'].aria.primary_navigation}}" class="usa-nav">
       <div class="usa-nav__inner">
         <button class="usa-nav__close">
-          {% asset img/usa-icons/close.svg alt="{{site.data[lang]['i18n'].aria.close}}" %}
+          {% asset img/usa-icons/close.svg alt="{{site.data["en"]['i18n'].aria.close}}" %}
         </button>
         <ul class="usa-nav__primary usa-accordion">
           {% for nav_item in site.primary_navigation %} {% unless
@@ -30,10 +30,10 @@
             class="usa-nav__primary-item desktop:text-no-wrap {{ nav_item.classes }}"
           >
             <a
-              href="{% if nav_item.external %}{{ nav_item.url[lang] }}{% else %}{{ nav_item.url[lang] | relative_url }}{% endif %}"
-              class="usa-nav__link{% if basedir == linkdir %} usa-current pa11y-skip {% endif %}"
+              href="{% if nav_item.external %}{{ nav_item.url['en'] }}{% else %}{{ nav_item.url['en'] | relative_url }}{% endif %}"
+              class="usa-nav__link{% if basedir == linkdir %} usa-current pa11y-skip {% elsif basedir=='es' and linkdir=='file-a-complaint' %} usa-current pa11y-skip {% endif %}"
             >
-              <span>{{ nav_item.name[lang] | escape }}</span>
+              <span>{{ nav_item.name["en"] | escape }}</span>
             </a>
           </li>
           {% else %} {% assign nav_id = 'primary-nav-' | append: forloop.index%}
@@ -45,7 +45,7 @@
               aria-expanded="false"
               aria-controls="{{ nav_id }}"
             >
-              <span>{{ nav_item.name[lang] | escape }}</span>
+              <span>{{ nav_item.name["en"] | escape }}</span>
             </button>
             <ul id="{{ nav_id }}" class="usa-nav__submenu">
               {% for subnav_item in nav_item.children %}
@@ -65,12 +65,12 @@
         <div
           class="display-flex order-3 desktop:display-none flex-align-start padding-left-6 padding-right-3 bg-primary-lighter margin-x-neg-3 padding-y-3 line-height-sans-5"
         >
-          {% asset ic_phone-circle.svg class="margin-right-1" alt="{{site.data[lang]['i18n'].aria.phone}}" %}
+          {% asset ic_phone-circle.svg class="margin-right-1" alt="{{site.data["en"]['i18n'].aria.phone}}" %}
           <div>
             <span class="display-block margin-bottom-05 text-bold"
-              >{{site.data[lang]["i18n"].hotline.heading}}</span
+              >{{site.data["en"]["i18n"].hotline.heading}}</span
             >
-            {{site.data[lang]["i18n"].hotline.content}}<br />
+            {{site.data["en"]["i18n"].hotline.content}}<br />
             {{ site.contact.tollfree }}<br />
             {{ site.contact.tty }} (TTY)
           </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,7 +59,7 @@
           </li>
           {% endunless %} {% endfor %}
         </ul>
-        <div class="usa-nav__secondary {{shrink}}">
+        <div class="usa-nav__secondary">
           {% include searchgov/form.html searchgov=site.searchgov %}
         </div>
         <div

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <div class="grid-container crt-landing--logo_section">

--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <div class="bg-warning padding-y-2 font-sans-2xs">

--- a/_includes/phone.html
+++ b/_includes/phone.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 <div
   class="crt-phone display-none desktop:display-flex flex-align-center bg-primary-darker text__reverse radius-bottom-md position-absolute pin-right pin-top margin-right-4 padding-x-3 padding-y-2"

--- a/_includes/redirect-modal.html
+++ b/_includes/redirect-modal.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 <div id="external-link--modal" hidden>
   <div

--- a/_includes/touchpoints.html
+++ b/_includes/touchpoints.html
@@ -1,4 +1,4 @@
-{% assign lang = page.lang %}
+{% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
 <a

--- a/_pages/es/presente-una-queja.md
+++ b/_pages/es/presente-una-queja.md
@@ -39,7 +39,7 @@ Existen tres opciones para la presentación de una queja:
 1. En línea
 Siga las instrucciones en el [sitio web del DOJ](https://civilrights.justice.gov/report/)
 1. Por correo ordinario
-Rellene y envíe la versión impresa del [Formulario de quejas al amparo de la ADA](https://www.ada.gov/CRT-ReportPDF-Sep2021.pdf) or o una carta que contiene la misma información, a:
+Rellene y envíe la versión impresa del [Formulario de quejas al amparo de la ADA (en inglés)](https://www.ada.gov/CRT-ReportPDF-Sep2021.pdf) or o una carta que contiene la misma información, a:
 >U.S. Department of Justice<br/>
 Civil Rights Division<br/>
 950 Pennsylvania Avenue, NW<br/>


### PR DESCRIPTION
Rationale:
1. To bring our translated page into alignment with suggestions from the LEP (Low English Proficiency) website recommendations, we have opted to only show the body content of the page in Spanish.

Changes:
1. The 'lang' variable is set to 'en' in the following components: `banner.html`, `banner-beta.html`, `footer.html`, `header.html`, `logo.html`, `notice.html`, `phone.html`, `redirect-modal.html`, `touchpoints.html`
2. This change ensures that the components will only pull in data from the english i18n file, and also only the english names and urls for navigation.
3. `header.html` has another change in it for setting the active class on the current navigation link. Since we only have one page at the moment we are just saying "If the basedir is "es" and you're on the presente-una-queja page then make this the active item.
4. Presente-una-queja.md - added (en ingles) to the link text