### PR TITLE
Null alt text added to warning icon

### DIFF
--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -9,7 +9,8 @@
         {% asset img/usa-icons/warning.svg class="usa-icon margin-right-05"
         aria-hidden="true"
         focusable="false"
-        role="img"%}
+        role="img"
+        alt=""%}
         <a
           class="text-no-underline hover:text-ink hover:text-underline"
           href="{{ post.url | relative_url }}"


### PR DESCRIPTION
Rationale:
1. The Wave accessibility extension flagged the warning icon in the COVID notice text as not having an alt tag.
2. This is an accessibility issue.
3. The icon is decorative and hidden using aria, so it needs a null tag.

Changes:
1. In `notice.html` a null alt tag (alt="") has been added to the icon markdown.

Testing:
1. Open the preview link and run the Wave extension. The error should not be present.
2. Perform an audit of the page using Axe dev tools. There should not be an error.