### PR TITLE
Screen reader text passes contrast checks

### DIFF
--- a/_assets/css/custom/_buttons.scss
+++ b/_assets/css/custom/_buttons.scss
@@ -20,6 +20,10 @@
   }
 }
 
+span.usa-sr-only {
+  color: black;
+}
+
 @media screen and (min-width: 0px) {
   #crt-page--printbutton--wrapper {
     display: none;

--- a/_assets/css/custom/_search.scss
+++ b/_assets/css/custom/_search.scss
@@ -15,6 +15,10 @@
   max-width: 27ch !important;
 }
 
+label.usa-sr-only {
+  color: white;
+}
+
 @include at-media(desktop) {
   .usa-search--small input[type="search"] {
     border-color: color("white");


### PR DESCRIPTION
Rationale:
1. Screen reader only text doesn't have proper color contrast in mind, nor is it relevant, however Axe Dev Tools and Wave accessibility checker don't know this. Waves flags it as an error because the absolute positioning of the text is removed when the site is checked, thus the text then overlays the other elements and causes a contrast error.

Changes:
1. _buttons.scss - added a rule for span.usa-sr-only class specifying that the text be black.
2. _search.scss - added a rule for label.usa-sr-only class specifying that the text be white.

Testing:
1. Open the preview page and run Waves and Axe Devtools. No errors should appear.