### PR TITLE
Small change to properly link alternate pages for i18n.

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -19,7 +19,7 @@
   {% seo %}
   <meta http-equiv="Content-Language" content={{lang}}>
   {% for item in pages %}
-    {% if item.lang!=lang and item.ref!=nil and item.ref==ref %}
+    {% if item.ref!=nil and item.ref==ref %}
       <link rel="alternate" hreflang={{item.lang}} href={{item.url | relative}}>
     {% endif%}
   {% endfor %}


### PR DESCRIPTION
Rationale:
1. According to Google, to properly have alternate language pages indexed, both the translation and the original page need to be listed in the `<head>` tag. [Link](https://developers.google.com/search/docs/advanced/crawling/localized-versions#html)

Change:
1. In `meta.html` the condition `item.lang!=lang` was removed from the if check for the alternate languages.

Test:
1. In the preview, check the meta tags within the head section. On pages with a translation available (file a complaint, presente una queja) both the current page and it's translation should be listed in the head section as alternate language link tags. 