### PR TITLE
Changed relative to relative_url

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -20,7 +20,7 @@
   <meta http-equiv="Content-Language" content={{lang}}>
   {% for item in pages %}
     {% if item.ref!=nil and item.ref==ref %}
-      <link rel="alternate" hreflang={{item.lang}} href={{item.url | relative}}>
+      <link rel="alternate" hreflang={{item.lang}} href={{item.url | relative_url }}>
     {% endif%}
   {% endfor %}
   <!-- CSS


### PR DESCRIPTION
Changes:
1. In meta.html changed the nonexistent 'relative' liquid filter to 'relative_url'

Test:
1. Meta content should contain proper urls now.