### PR TITLE
Added print button to the web guidance page

### DIFF
--- a/_pages/web-guidance.md
+++ b/_pages/web-guidance.md
@@ -7,9 +7,9 @@ lead: |-
 lang: "en"
 news-item: true
 publish-date: 2022-03-18 00:00:00
-
+print: true
 ---
-[Learn more about businesses' and state and local governments' ADA responsibilities.]( {{'/topics/intro-to-ada'| relative_url}})  
+[Learn more about businesses' and state and local governments' ADA responsibilities.]( {{'/topics/intro-to-ada'| relative_url}})
 
 ## Why Website Accessibility Matters
 
@@ -21,11 +21,11 @@ The ways that websites are designed and set up can create unnecessary barriers t
 
 ## Examples of Website Accessibility Barriers
 
-- **Poor color contrast.**  People with limited vision or color blindness cannot read text if there is not enough contrast between the text and background (for example, light gray text on a light-colored background).  
+- **Poor color contrast.**  People with limited vision or color blindness cannot read text if there is not enough contrast between the text and background (for example, light gray text on a light-colored background).
 
-- **Use of color alone to give information.**  People who are color-blind may not have access to information when that information is conveyed using only color cues because they cannot distinguish certain colors from others.  Also, screen readers do not tell the user the color of text on a screen, so a person who is blind would not be able to know that color is meant to convey certain information (for example, using red text alone to show which fields are required on a form).  
+- **Use of color alone to give information.**  People who are color-blind may not have access to information when that information is conveyed using only color cues because they cannot distinguish certain colors from others.  Also, screen readers do not tell the user the color of text on a screen, so a person who is blind would not be able to know that color is meant to convey certain information (for example, using red text alone to show which fields are required on a form).
 
-- **Lack of text alternatives (“alt text”) on images.**  People who are blind will not be able to understand the content and purpose of images, such as pictures, illustrations, and charts, when no text alternative is provided.  Text alternatives convey the purpose of an image, including pictures, illustrations, charts, etc.  
+- **Lack of text alternatives (“alt text”) on images.**  People who are blind will not be able to understand the content and purpose of images, such as pictures, illustrations, and charts, when no text alternative is provided.  Text alternatives convey the purpose of an image, including pictures, illustrations, charts, etc.
 
 - **No captions on videos.**  People with hearing disabilities may not be able to understand information communicated in a video if the video does not have captions.
 
@@ -36,104 +36,104 @@ The ways that websites are designed and set up can create unnecessary barriers t
 
 - **Mouse-only navigation (lack of keyboard navigation).**  People with disabilities who cannot use a mouse or trackpad will not be able to access web content if they cannot navigate a website using a keyboard.
 
-## When the ADA Requires Web Content to be Accessible  
+## When the ADA Requires Web Content to be Accessible
 
 **The Americans with Disabilities Act applies to state and local governments (Title II) and businesses that are open to the public (Title III).**
 
-### State and local governments (Title II)  
+### State and local governments (Title II)
 
-Title II of the ADA prohibits discrimination against people with disabilities in all services, programs, and activities of state and local governments.  State and local governments must take steps to ensure that their communications with people with disabilities are as effective as their communications with others.   Many state and local government services, programs, and activities are now being offered on the web.  These include, for example, things like:  
+Title II of the ADA prohibits discrimination against people with disabilities in all services, programs, and activities of state and local governments.  State and local governments must take steps to ensure that their communications with people with disabilities are as effective as their communications with others.   Many state and local government services, programs, and activities are now being offered on the web.  These include, for example, things like:
 
-- Applying for an absentee ballot;  
-- Paying tickets or fees;  
-- Filing a police report;  
-- Attending a virtual town meeting;  
-- Filing tax documents;  
-- Registering for school or school programs; and  
-- Applying for state benefits programs.  
+- Applying for an absentee ballot;
+- Paying tickets or fees;
+- Filing a police report;
+- Attending a virtual town meeting;
+- Filing tax documents;
+- Registering for school or school programs; and
+- Applying for state benefits programs.
 
-A website with inaccessible features can limit the ability of people with disabilities to access a public entity’s programs, services and activities available through that website—for example, online registration for classes at a community college.  
+A website with inaccessible features can limit the ability of people with disabilities to access a public entity’s programs, services and activities available through that website—for example, online registration for classes at a community college.
 
 **For these reasons, the Department has consistently taken the position that the ADA’s requirements apply to all the services, programs, or activities of state and local governments, including those offered on the web.**
 
-### Businesses that are open to the public (Title III)  
+### Businesses that are open to the public (Title III)
 
-Title III prohibits discrimination against people with disabilities by businesses open to the public (also referred to as “public accommodations” under the ADA). The ADA requires that businesses open to the public provide full and equal enjoyment of their goods, services, facilities, privileges, advantages, or accommodations to people with disabilities.  Businesses open to the public must take steps to provide appropriate communication aids and services (often called “auxiliary aids and services”) where necessary to make sure they effectively communicate with individuals with disabilities.  For example, communication aids and services can include interpreters, notetakers, captions, or assistive listening devices.  Examples of businesses open to the public:  
+Title III prohibits discrimination against people with disabilities by businesses open to the public (also referred to as “public accommodations” under the ADA). The ADA requires that businesses open to the public provide full and equal enjoyment of their goods, services, facilities, privileges, advantages, or accommodations to people with disabilities.  Businesses open to the public must take steps to provide appropriate communication aids and services (often called “auxiliary aids and services”) where necessary to make sure they effectively communicate with individuals with disabilities.  For example, communication aids and services can include interpreters, notetakers, captions, or assistive listening devices.  Examples of businesses open to the public:
 
-- Retail stores and other sales or retail establishments;  
-- Banks;  
-- Hotels, inns, and motels;  
-- Hospitals and medical offices;  
-- Food and drink establishments; and  
-- Auditoriums, theaters, and sports arenas.  
+- Retail stores and other sales or retail establishments;
+- Banks;
+- Hotels, inns, and motels;
+- Hospitals and medical offices;
+- Food and drink establishments; and
+- Auditoriums, theaters, and sports arenas.
 
-A website with inaccessible features can limit the ability of people with disabilities to access a public accommodation’s goods, services, and privileges available through that website—for example, a veterans’ service organization event registration form.  
+A website with inaccessible features can limit the ability of people with disabilities to access a public accommodation’s goods, services, and privileges available through that website—for example, a veterans’ service organization event registration form.
 
-**For these reasons, the Department has consistently taken the position that the ADA’s requirements apply to all the goods, services, privileges, or activities offered by public accommodations, including those offered on the web.**  
+**For these reasons, the Department has consistently taken the position that the ADA’s requirements apply to all the goods, services, privileges, or activities offered by public accommodations, including those offered on the web.**
 
-## How to Make Web Content Accessible to People with Disabilities  
+## How to Make Web Content Accessible to People with Disabilities
 
-**Businesses and state and local governments have flexibility in how they comply with the ADA’s general requirements of nondiscrimination and effective communication.  But they must comply with the ADA’s requirements.**  
+**Businesses and state and local governments have flexibility in how they comply with the ADA’s general requirements of nondiscrimination and effective communication.  But they must comply with the ADA’s requirements.**
 
 The Department of Justice does not have a regulation setting out detailed standards, but the Department’s longstanding interpretation of the general nondiscrimination and effective communication provisions applies to web accessibility.<sup id="fnref:1"><a href="#fn:1" class="footnote" rel="footnote">1</a></sup>
 
-Businesses and state and local governments can currently choose how they will ensure that the programs, services, and goods they provide online are accessible to people with disabilities.  
+Businesses and state and local governments can currently choose how they will ensure that the programs, services, and goods they provide online are accessible to people with disabilities.
 
 Existing technical standards provide helpful guidance concerning how to ensure accessibility of website features.  These include the [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/wai/standards-guidelines/wcag/) and the [Section 508 Standards](https://www.access-board.gov/ict/), which the federal government uses for its own websites.  [Check out the resources section for more references](#res).
 
-**Even though businesses and state and local governments have flexibility in how they comply with the ADA’s general requirements of nondiscrimination and effective communication, they still must ensure that the programs, services, and goods that they provide to the public—including those provided online—are accessible to people with disabilities.**  
+**Even though businesses and state and local governments have flexibility in how they comply with the ADA’s general requirements of nondiscrimination and effective communication, they still must ensure that the programs, services, and goods that they provide to the public—including those provided online—are accessible to people with disabilities.**
 
 {% details Businesses and state and local governments should consider a variety of website features when ensuring that their websites are accessible. %}
-The [resources section](#res) has links to organizations that explain how to make websites accessible.  Examples of what businesses should do to make websites accessible include (but are not limited to) the following practices:  
+The [resources section](#res) has links to organizations that explain how to make websites accessible.  Examples of what businesses should do to make websites accessible include (but are not limited to) the following practices:
 
-- **Color contrast in text.**  Sufficient color contrast between the text and the background allows people with limited vision or color blindness to read text that uses color.  
+- **Color contrast in text.**  Sufficient color contrast between the text and the background allows people with limited vision or color blindness to read text that uses color.
 
-- **Text cues when using color in text.**  When using text color to provide information (such as red text to indicate required form fields), including text cues is important for people who cannot perceive the color.  For example, include the word “required” in addition to red text for required form fields.  
+- **Text cues when using color in text.**  When using text color to provide information (such as red text to indicate required form fields), including text cues is important for people who cannot perceive the color.  For example, include the word “required” in addition to red text for required form fields.
 
-- **Text alternatives (“alt text”) in images.**  Text alternatives convey the purpose of an image, including pictures, illustrations, charts, etc.  Text alternatives are used by people who do not see the image, such as people who are blind and use screen readers to hear the alt text read out loud.  To be useful, the text should be short and descriptive.  
+- **Text alternatives (“alt text”) in images.**  Text alternatives convey the purpose of an image, including pictures, illustrations, charts, etc.  Text alternatives are used by people who do not see the image, such as people who are blind and use screen readers to hear the alt text read out loud.  To be useful, the text should be short and descriptive.
 
-- **Video captions.**  Videos can be made accessible by including synchronized captions that are accurate and identify any speakers in the video.  
+- **Video captions.**  Videos can be made accessible by including synchronized captions that are accurate and identify any speakers in the video.
 
-- **Online forms.**  Labels, keyboard access, and clear instructions are important for forms to be accessible.  Labels allow people who are blind and using screen readers to understand what to do with each form field, such as by explaining what information goes in each box of a job application form.  It is also important to make sure that people who are using screen readers are automatically informed when they enter a form field incorrectly.  This includes clearly identifying what the error is and how to resolve it (such as an automatic alert telling the user that a date was entered in the wrong format).  
+- **Online forms.**  Labels, keyboard access, and clear instructions are important for forms to be accessible.  Labels allow people who are blind and using screen readers to understand what to do with each form field, such as by explaining what information goes in each box of a job application form.  It is also important to make sure that people who are using screen readers are automatically informed when they enter a form field incorrectly.  This includes clearly identifying what the error is and how to resolve it (such as an automatic alert telling the user that a date was entered in the wrong format).
 
-- **Text size and zoom capability.**  People with vision disabilities may need to be able to use a browser’s zoom capabilities to increase the size of the font so they can see things more clearly.  
+- **Text size and zoom capability.**  People with vision disabilities may need to be able to use a browser’s zoom capabilities to increase the size of the font so they can see things more clearly.
 
-- **Headings.**  When sections of a website are separated by visual headings, building those headings into the website’s layout when designing the page allows people who are blind to use them to navigate and understand the layout of the page.  
+- **Headings.**  When sections of a website are separated by visual headings, building those headings into the website’s layout when designing the page allows people who are blind to use them to navigate and understand the layout of the page.
 
-- **Keyboard and mouse navigation.**  Keyboard access means users with disabilities can navigate web content using keystrokes, rather than a mouse.  
+- **Keyboard and mouse navigation.**  Keyboard access means users with disabilities can navigate web content using keystrokes, rather than a mouse.
 
-- **Checking for accessibility.**  Automated accessibility checkers and overlays that identify or fix problems with your website can be helpful tools, but like other automated tools such as spelling or grammar checkers, they need to be used carefully.  A “clean” report does not necessarily mean everything is accessible.  Also, a report that includes a few errors does not necessarily mean there are accessibility barriers.  Pairing a manual check of a website with the use of automated checkers can give you a better sense of the accessibility of your website.  
+- **Checking for accessibility.**  Automated accessibility checkers and overlays that identify or fix problems with your website can be helpful tools, but like other automated tools such as spelling or grammar checkers, they need to be used carefully.  A “clean” report does not necessarily mean everything is accessible.  Also, a report that includes a few errors does not necessarily mean there are accessibility barriers.  Pairing a manual check of a website with the use of automated checkers can give you a better sense of the accessibility of your website.
 
-- **Reporting accessibility issues.**  Websites that provide a way for the public to report accessibility problems allow website owners to fix accessibility issues.  
+- **Reporting accessibility issues.**  Websites that provide a way for the public to report accessibility problems allow website owners to fix accessibility issues.
 
 **This is not a complete list of things to consider.**  There are many existing resources to help businesses and state and local governments with making websites accessible to people with disabilities, [some of which are included at the end of this document](#res).
 {% enddetails %}
 
-## Web Accessibility for People with Disabilities is a Priority for the Department of Justice  
+## Web Accessibility for People with Disabilities is a Priority for the Department of Justice
 
-When Congress enacted the ADA in 1990, it intended for the ADA to keep pace with the rapidly changing technology of our times.  Since 1996, the Department of Justice has consistently taken the position that the ADA applies to web content.  As the sample cases below show, the Department is committed to using its enforcement authority to ensure website accessibility for people with disabilities and to ensure that the goods, services, programs, and activities that businesses and state and local governments make available to the public are accessible.  
+When Congress enacted the ADA in 1990, it intended for the ADA to keep pace with the rapidly changing technology of our times.  Since 1996, the Department of Justice has consistently taken the position that the ADA applies to web content.  As the sample cases below show, the Department is committed to using its enforcement authority to ensure website accessibility for people with disabilities and to ensure that the goods, services, programs, and activities that businesses and state and local governments make available to the public are accessible.
 
-### Title II Sample Cases  
+### Title II Sample Cases
 
-- [Project Civic Access](https://www.ada.gov/civicac.htm): As part of the Department’s Project Civic Access enforcement work, the Department has reached numerous agreements with cities and counties across the country that include web accessibility requirements.  For example, [City and County of Denver, Colorado](https://www.ada.gov/denver_pca/denver_sa.html), [City of Jacksonville, Florida](https://www.ada.gov/jacksonville_pca/jacksonville_pca_sa.htm), and [City of Durham, North Carolina](https://www.ada.gov/DurhamNCpca.htm).  
-- [Miami University in Ohio](https://www.ada.gov/miami_university_cd.html): The Department reached an agreement with Miami University in Ohio to resolve the United States’ lawsuit alleging that the university discriminated against students with disabilities by providing inaccessible web content and learning management systems.  
-- [Nueces County, Texas](https://www.ada.gov/nueces_co_tx_pca/nueces_co_tx_sa.html): The Department reached an agreement with Nueces County, Texas, to address claims that the County used an online conference registration form that was not accessible to people with disabilities who use software that reads text out loud.  
-- [Louisiana Tech](https://www.ada.gov/louisiana-tech.htm): The Department reached an agreement with Louisiana Tech University to address claims that the university violated the ADA by using an online learning product that was inaccessible to a blind student.  
+- [Project Civic Access](https://www.ada.gov/civicac.htm): As part of the Department’s Project Civic Access enforcement work, the Department has reached numerous agreements with cities and counties across the country that include web accessibility requirements.  For example, [City and County of Denver, Colorado](https://www.ada.gov/denver_pca/denver_sa.html), [City of Jacksonville, Florida](https://www.ada.gov/jacksonville_pca/jacksonville_pca_sa.htm), and [City of Durham, North Carolina](https://www.ada.gov/DurhamNCpca.htm).
+- [Miami University in Ohio](https://www.ada.gov/miami_university_cd.html): The Department reached an agreement with Miami University in Ohio to resolve the United States’ lawsuit alleging that the university discriminated against students with disabilities by providing inaccessible web content and learning management systems.
+- [Nueces County, Texas](https://www.ada.gov/nueces_co_tx_pca/nueces_co_tx_sa.html): The Department reached an agreement with Nueces County, Texas, to address claims that the County used an online conference registration form that was not accessible to people with disabilities who use software that reads text out loud.
+- [Louisiana Tech](https://www.ada.gov/louisiana-tech.htm): The Department reached an agreement with Louisiana Tech University to address claims that the university violated the ADA by using an online learning product that was inaccessible to a blind student.
 
-### Title III Sample Cases  
+### Title III Sample Cases
 
-- [Rite Aid Corporation](https://www.ada.gov/rite_aid_sa.pdf): The Department reached an agreement with Rite Aid Corporation to address accessibility barriers in Rite Aid’s COVID-19 Vaccine Registration Portal.  
-- [Teachers Test Prep, Inc.](https://www.ada.gov/ttp_sa.html): The Department reached an agreement with Teachers Test Prep, Inc., regarding complaints that the test prep company’s online video courses did not provide captions and were inaccessible to people who are deaf.  
-- [HRB Digital and HRB Tax Group (H&R Block)](https://www.ada.gov/hrb-cd.htm): The Department reached an agreement with H&R Block to address claims that the company failed to code its website so that individuals with disabilities could use assistive technology such as screen reader software, refreshable Braille displays, keyboard navigation, and captioning.  
+- [Rite Aid Corporation](https://www.ada.gov/rite_aid_sa.pdf): The Department reached an agreement with Rite Aid Corporation to address accessibility barriers in Rite Aid’s COVID-19 Vaccine Registration Portal.
+- [Teachers Test Prep, Inc.](https://www.ada.gov/ttp_sa.html): The Department reached an agreement with Teachers Test Prep, Inc., regarding complaints that the test prep company’s online video courses did not provide captions and were inaccessible to people who are deaf.
+- [HRB Digital and HRB Tax Group (H&R Block)](https://www.ada.gov/hrb-cd.htm): The Department reached an agreement with H&R Block to address claims that the company failed to code its website so that individuals with disabilities could use assistive technology such as screen reader software, refreshable Braille displays, keyboard navigation, and captioning.
 - [Peapod](https://www.ada.gov/peapod_sa.htm): The Department reached an agreement with Peapod to address claims that its online grocery delivery services were not accessible to some individuals with disabilities.
 
-## <a name="res"></a>Resources  
+## <a name="res"></a>Resources
 
-- [18F Accessibility Guide](https://accessibility.18f.gov/): a comprehensive accessibility guide with resources published by 18F, a digital services agency under the General Services Administration (GSA).  
-- [Digital.gov](https://digital.gov/topics/accessibility/): this site, which is part of the Technology Transformation Services at the GSA, has resources on design of products, devices, services, or environments for people with disabilities.  
-- [Section 508 Information and Communication Technology Accessibility Standards](https://www.access-board.gov/ict/): standards published by the U.S. Access Board addressing access to information and communication technology under Section 508 of the Rehabilitation Act of 1973.  
-- [Section508.gov](https://www.section508.gov/): a website published by the GSA with tools and training on implementing website accessibility requirements under Section 508.  
-- [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/wai/standards-guidelines/wcag/): guidelines published by the Web Accessibility Initiative of the World Wide Web Consortium.  
+- [18F Accessibility Guide](https://accessibility.18f.gov/): a comprehensive accessibility guide with resources published by 18F, a digital services agency under the General Services Administration (GSA).
+- [Digital.gov](https://digital.gov/topics/accessibility/): this site, which is part of the Technology Transformation Services at the GSA, has resources on design of products, devices, services, or environments for people with disabilities.
+- [Section 508 Information and Communication Technology Accessibility Standards](https://www.access-board.gov/ict/): standards published by the U.S. Access Board addressing access to information and communication technology under Section 508 of the Rehabilitation Act of 1973.
+- [Section508.gov](https://www.section508.gov/): a website published by the GSA with tools and training on implementing website accessibility requirements under Section 508.
+- [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/wai/standards-guidelines/wcag/): guidelines published by the Web Accessibility Initiative of the World Wide Web Consortium.
 
 <div class="footnotes">
 <ol>


### PR DESCRIPTION
Changes:
1. Set `print-true` on the Web Guidance TA page

Test:
Confirm that the print button appears only on desktop screen widths.
Confirm that the print button prints and displays the accordions in expanded state.