### PR TITLE
Added alt text for the seal logo

### DIFF
--- a/_data/en/i18n.yml
+++ b/_data/en/i18n.yml
@@ -52,6 +52,7 @@ banner:
   block_copy_https_sub: or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
   padlock_title: Lock
   padlock_description: A locked padlock
+  doj_seal: Official Seal of the United States Department of Justice
 footer:
   foia: FOIA
   photo_collection: Disabled And Here photo collection

--- a/_data/en/i18n.yml
+++ b/_data/en/i18n.yml
@@ -52,7 +52,7 @@ banner:
   block_copy_https_sub: or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
   padlock_title: Lock
   padlock_description: A locked padlock
-  doj_seal: Official Seal of the United States Department of Justice
+  doj_seal: The United States Department of Justice
 footer:
   foia: FOIA
   photo_collection: Disabled And Here photo collection

--- a/_data/es/i18n.yml
+++ b/_data/es/i18n.yml
@@ -52,6 +52,7 @@ banner:
   block_copy_https_sub: o https:// significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros.
   padlock_title: Candado
   padlock_description: Un candado cerrado
+  doj_seal: Official Seal of the United States Department of Justice
 footer:
   foia: FOIA [Ley de Libertad de Información]
   photo_collection: Colección de fotos Discapacitado y Aquí

--- a/_data/es/i18n.yml
+++ b/_data/es/i18n.yml
@@ -52,7 +52,7 @@ banner:
   block_copy_https_sub: o https:// significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros.
   padlock_title: Candado
   padlock_description: Un candado cerrado
-  doj_seal: Official Seal of the United States Department of Justice
+  doj_seal: The United States Department of Justice
 footer:
   foia: FOIA [Ley de Libertad de Información]
   photo_collection: Colección de fotos Discapacitado y Aquí

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
     <div class="grid-container usa-footer__logo-section">
       <div class="usa-footer__logo grid-row grid-gap-1">
         <div class="grid-col-auto">
-          {% asset doj-logo.png alt="" %}
+          {% asset doj-logo.png alt="{{ site.data[lang]['i18n'].banner.doj_seal }}" %}
         </div>
         <div class="grid-col-auto">
           <div class="display-flex flex-align-center">

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -7,7 +7,7 @@
     class="usa-footer__logo grid-row flex-align-start"
   >
     <div class="flex-none">
-      {% asset doj-logo.png alt="" class="margin-right-1" %}
+      {% asset doj-logo.png alt="{{ site.data[lang]['i18n'].banner.doj_seal }}" class="margin-right-1" %}
     </div>
     <div class="grid-col">
       <div class="display-flex flex-align-center">


### PR DESCRIPTION
Changes:

1.  Added new data field to both the spanish and english translation files: `doj_seal`
2.  Added this field to the `logo.html` and `footer.html` `_includes` files
3.  Alt text is taken from the justice.gov website alt text and reads: "The United States Department of Justice"