### PR TITLE
Added dates to the homepage ta docs and fixed typo in the web accessibility lead text

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -26,6 +26,13 @@ layout: default
       <div class="measure-6">
         {% if page.lead %}
           <div class="crt-lead">
+            {% if page.publish-date %}
+        <p>
+          <time datetime="{{page.publish-date | date_to_long_rfc822}}"
+            >{{ page.publish-date | date: "%B %d, %Y"}}
+          </time>
+        </p>
+        {% endif %}
             {{page.lead | markdownify}}
           </div>
         {% endif %}

--- a/_pages/web-guidance.md
+++ b/_pages/web-guidance.md
@@ -1,6 +1,6 @@
 ---
 title: Guidance on Web Accessibility and the ADA
-description: "The Department of Justice published guidance today on web accessibility and the Americans with Disabilities Act (ADA).  It explains how state and local governments (entities covered by ADA Title II) and businesses open to the public (entities covered by ADA Title III) can make sure their websites are accessible to people with disabilities in line with the ADA’s requirements."
+description: "The Department of Justice published guidance on web accessibility and the Americans with Disabilities Act (ADA).  It explains how state and local governments (entities covered by ADA Title II) and businesses open to the public (entities covered by ADA Title III) can make sure their websites are accessible to people with disabilities in line with the ADA’s requirements."
 permalink: /web-guidance/
 lead: |-
   This guidance describes how state and local governments and businesses open to the public can make sure that their websites are accessible to people with disabilities as required by the Americans with Disabilities Act (ADA).


### PR DESCRIPTION
Changes:
1. To the main page.html template I added a section that will pull in the publish date and display it above the lead text.
2. Fixed a small typo in the description text of the web accessibility markdown document.