### PR TITLE
Updating h1s to match new navigation terms

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ primary_navigation:
       es: "/law-and-regs/"
   - name:
       en: View Guidance & Resource Materials
-      en-short: View Guidance
+      en-short: View Resources
       es: View Guidance & Resource Materials
     url:
       en: "/resources/"

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -31,6 +31,6 @@
 {% if page.title == 'Give Us Feedback' %}
 <script src="https://touchpoints.app.cloud.gov/touchpoints/73c5715c.js" async></script>
 {% endif %}
-{% if page.title == 'Resources'%}
+{% if page.title == 'View Guidance & Resource Materials'%}
 {% asset dist/taResources-compiled.js %}
 {% endif %}

--- a/_includes/skipnav.html
+++ b/_includes/skipnav.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% if has_side_nav %}
-{% unless page.title == 'Resources'%}
+{% unless page.title == 'View Guidance & Resource Materials'%}
 <a class="usa-skipnav" href="#crt-page--sidenav">{{site.data[lang]["i18n"].links.skip.nav}}</a>
 {% endunless %}
 {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
   <div class="grid-row grid-gap-xl">
     {% if page.sidenav %}
     <div id="crt-page--sidenav" class="desktop:grid-col-4">
-      {% if page.title =='Resources' %}
+      {% if page.title =='View Guidance & Resource Materials' %}
         {% include ta-left-rail.html %}
       {% else %}
       {% include sidenav.html %}

--- a/_pages/law-and-regs/index.md
+++ b/_pages/law-and-regs/index.md
@@ -1,6 +1,6 @@
 ---
 permalink: /law-and-regs/
-title: Law and Regulations
+title: Review Laws, Regulations & Standards
 sidenav: false
 ---
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -1,6 +1,6 @@
 ---
 permalink: /resources/
-title: Resources
+title: View Guidance & Resource Materials
 lead: Information for people with disabilities, state and local governments, and businesses
 ---
 

--- a/_pages/topics.md
+++ b/_pages/topics.md
@@ -1,6 +1,6 @@
 ---
 permalink: /topics/
-title: Topics
+title: Explore Featured Topics
 layout: full
 lead: Information for people with disabilities, state and local governments, and businesses
 ---

--- a/tests/menu-button-mobile.spec.js
+++ b/tests/menu-button-mobile.spec.js
@@ -3,11 +3,10 @@ const { test, expect } = require('@playwright/test');
 const HOME = 'http://localhost:4000/';
 const LINKS = [
   'Home',
-  'Topics',
-  'Laws & Regulations',
+  'Explore Featured Topics',
+  'Review Laws, Regulations & Standards',
   'File a Complaint',
-  'Cases',
-  'Resources',
+  'View Guidance & Resource Materials',
 ];
 const INFOLINE = 'ADA Information Line';
 


### PR DESCRIPTION
@chinelo-ikejimba Caught that the h1's on each page were not updated to match the new navigation terms. This Pull Request fixes that. The 'title' field in the front matter of each page now matches the title item in the _config.yml file. 