### PR TITLE
Bump rack version to 2.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)


### PR DESCRIPTION
Bumped Rack version to 2.2.3.1

To test:

1. Pull down branch
2. Build and test locally 
3. Confirm no issues in Jekyll build
4. Confirm no issues in Federalist preview