### PR TITLE
Removing the search.js script from Jekyll build process into webpack.

### DIFF
--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -3,7 +3,6 @@
 //= require anchor.min.js 
 //= require ./modal.js
 //= require ./redirect-modal.js
-//= require ./search.js
 
 var anchors = new AnchorJS();
 anchors.add(".crt-page h2:not([class*='usa']) h2:not(.noAnchor)");

--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -1,9 +1,13 @@
-var queryString = window.location.search;
+const search = () => {
+  const queryString = window.location.search;
 
-if (queryString) {
-  var input = document.getElementById("query");
-  var params = new URLSearchParams(queryString.substring(1));
-  var value = params.get("query");
+  if (queryString) {
+    const input = document.getElementById('query');
+    const params = new URLSearchParams(queryString.substring(1));
+    const value = params.get('query');
 
-  if (value) input.value = value;
-}
+    if (value) input.value = value;
+  }
+};
+
+search();

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -26,6 +26,7 @@
 {% asset dist/print-compiled.js !type %}
 {% asset dist/printButton-compiled.js !type %}
 {% asset dist/accordion-compiled.js !type %} 
+{% asset dist/search-compiled.js !type %} 
 {% if page.title == 'Search' %} {% asset dist/pagination-compiled.js !type %} {% endif %} 
 {% if page.title == 'Give Us Feedback' %}
 <script src="https://touchpoints.app.cloud.gov/touchpoints/73c5715c.js" async></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
     accordion: './_assets/js/expand-accordions.js',
     taResources: './_assets/js/ta-selectors.js',
     print: './_assets/js/print.js',
-    printButton: "./_assets/js/print-button.js"
+    printButton: "./_assets/js/print-button.js",
+    search: "./_assets/js/search.js",
   },
   output: {
     path: path.resolve(__dirname, './_assets/js/', 'dist'),


### PR DESCRIPTION
 The search.js script has been changed into a named function and is built in the Webpack build process. It is no longer built by Sprockets/Jekyll Assets. 

To test:
1. Open the preview url below
2. Confirm that you can search a variety of terms from every page
3. Confirm that there are no console errors.