### PR TITLE
Moving modal and redirect modal out from Jekyll build pipeline into Webpack

### DIFF
--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -1,8 +1,6 @@
 //= require js/uswds.min.js
 //= require gumshoe.polyfills.min.js
 //= require anchor.min.js 
-//= require ./modal.js
-//= require ./redirect-modal.js
 //= require ./search.js
 
 var anchors = new AnchorJS();

--- a/_assets/js/modal.js
+++ b/_assets/js/modal.js
@@ -1,32 +1,33 @@
-(function(root, dom) {
-  root.CRT = root.CRT || {};
+const modal = () => {
+  const dom = document;
+  window.CRT = window.CRT || {};
 
-  var previous_onkeydown = dom.onkeydown;
-  var focusable_elements =
+  const previous_onkeydown = dom.onkeydown;
+  const focusable_elements =
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
-  root.CRT.openModal = function(modal_el) {
-    dom.onkeydown = function(event) {
+  window.CRT.openModal = function (modal_el) {
+    dom.onkeydown = function (event) {
       event = event || window.event;
-      var isEscape = false;
-      if ("key" in event) {
-        isEscape = event.key === "Escape" || event.key === "Esc";
+      const isEscape = false;
+      if ('key' in event) {
+        isEscape = event.key === 'Escape' || event.key === 'Esc';
       } else {
         isEscape = event.keyCode === 27;
       }
       if (isEscape) {
-        root.CRT.closeModal(modal_el);
+        window.CRT.closeModal(modal_el);
       }
-      var isTab = false;
-      if ("key" in event) {
-        isTab = event.key === "Tab";
+      const isTab = false;
+      if ('key' in event) {
+        isTab = event.key === 'Tab';
       } else {
-        isTab = event.keyCode === 9;
+        isTab = event.key === 9;
       }
       if (isTab) {
-        var first = modal_el.querySelectorAll(focusable_elements)[0];
-        var focusable_content = modal_el.querySelectorAll(focusable_elements);
-        var last = focusable_content[focusable_content.length - 1];
+        const first = modal_el.querySelectorAll(focusable_elements)[0];
+        const focusable_content = modal_el.querySelectorAll(focusable_elements);
+        const last = focusable_content[focusable_content.length - 1];
         if (event.shiftKey) {
           // browse clickable elements moving backwards
           if (document.activeElement === first) {
@@ -42,24 +43,26 @@
         }
       }
     };
-    modal_el.removeAttribute("hidden");
+    modal_el.removeAttribute('hidden');
     // get first input in this modal so we can focus on it
-    var first = modal_el.querySelectorAll(focusable_elements)[0];
+    const first = modal_el.querySelectorAll(focusable_elements)[0];
     first.focus();
-    dom.body.classList.add("is-modal");
+    dom.body.classList.add('is-modal');
   };
 
-  root.CRT.closeModal = function(modal_el) {
+  window.CRT.closeModal = function (modal_el) {
     dom.onkeydown = previous_onkeydown;
-    modal_el.setAttribute("hidden", "hidden");
-    dom.body.classList.remove("is-modal");
+    modal_el.setAttribute('hidden', 'hidden');
+    dom.body.classList.remove('is-modal');
   };
 
-  root.CRT.cancelModal = function(modal_el, cancel_el) {
-    var dismissModal = function(event) {
+  window.CRT.cancelModal = function (modal_el, cancel_el) {
+    const dismissModal = function (event) {
       event.preventDefault();
-      root.CRT.closeModal(modal_el);
+      window.CRT.closeModal(modal_el);
     };
-    cancel_el.addEventListener("click", dismissModal);
+    cancel_el.addEventListener('click', dismissModal);
   };
-})(window, document);
+};
+
+modal();

--- a/_assets/js/redirect-modal.js
+++ b/_assets/js/redirect-modal.js
@@ -1,18 +1,19 @@
-(function(root) {
+const redirectModal = () => {
   // note that modal.js must be loaded beforehand
-  var modal_el = document.getElementById("external-link--modal");
-  var span = document.getElementById("external-link--address");
-  var links = document.querySelectorAll(".external-link--popup");
-  var continue_button = document.getElementById("external-link--continue");
-  var redirect;
-  for (var i = 0; i < links.length; i++) {
-    var link = links[i];
+  const dom = document;
+  const modal_el = dom.getElementById("external-link--modal");
+  const span = dom.getElementById("external-link--address");
+  const links = dom.querySelectorAll(".external-link--popup");
+  const continue_button = dom.getElementById("external-link--continue");
+  let redirect;
+  for (const i = 0; i < links.length; i++) {
+    const link = links[i];
     link.onclick = function(event) {
-      var href = event.target.href;
+      const href = event.target.href;
       event.preventDefault();
       // display the actual redirect link
       span.innerHTML = '<a href="' + href + '">' + href + "</a>";
-      root.CRT.openModal(modal_el);
+      window.CRT.openModal(modal_el);
       // set timeout for redirect
       clearTimeout(redirect);
       redirect = setTimeout(function() {
@@ -25,11 +26,13 @@
       // set up "continue" button to immediately redirect
       continue_button.onclick = function(event) {
         event.preventDefault();
-        var href = span.children[0].href;
+        const href = span.children[0].href;
         window.location.href = href;
       };
     };
   }
-  var cancel_modal = document.getElementById("external-link--cancel");
-  root.CRT.cancelModal(modal_el, cancel_modal);
-})(window);
+  const cancel_modal = dom.getElementById("external-link--cancel");
+  window.CRT.cancelModal(modal_el, cancel_modal);
+};
+
+redirectModal();

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -23,6 +23,8 @@
 </script>
 {% endif %} 
 {% asset main.js !type %} 
+{% asset modal-compiled.js !type %}
+{% asset redirectModal-compiled.js !type %}
 {% asset dist/print-compiled.js !type %}
 {% asset dist/printButton-compiled.js !type %}
 {% asset dist/accordion-compiled.js !type %} 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
     accordion: './_assets/js/expand-accordions.js',
     taResources: './_assets/js/ta-selectors.js',
     print: './_assets/js/print.js',
-    printButton: "./_assets/js/print-button.js"
+    printButton: "./_assets/js/print-button.js",
+    modal: "./_assets/js/modal.js",
+    redirectModal: "./_assets/js/redirect-modal.js"
   },
   output: {
     path: path.resolve(__dirname, './_assets/js/', 'dist'),


### PR DESCRIPTION
modal.js and redirect-modal.js are now named functions that are called in each file. They are now built by webpack. They function identically to before the migration to Webpack. 

To test:
1. Open the preview url below
2. Open a link to an external page (you can try the Adobe Stock image link in the homepage footer)
3. Confirm that the modal works as on the existing beta.ada.gov site