### PR TITLE
Changing styling and text of download pdf button.

### DIFF
--- a/_assets/css/custom/_buttons.scss
+++ b/_assets/css/custom/_buttons.scss
@@ -15,6 +15,7 @@
 .crt-page--downloadpdf-button {
   background-color: color($theme-color-primary-darker);
   &:hover {
+    color: white !important;
     background: color($theme-link-hover-color);
   }
   &:focus {

--- a/_assets/css/custom/_sidenav.scss
+++ b/_assets/css/custom/_sidenav.scss
@@ -4,7 +4,7 @@
 }
 
 #crt-page--sidenav {
-  a:not(.crt-page--downloadpdf-link):not(.crt-page--downloadpdf-button)  {
+  a:not(.crt-page--downloadpdf-button)  {
     color: color($theme-text-color);
 
     &.usa-current {

--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -1,5 +1,8 @@
-{% assign titleLength = include.title | size %}
-
-<div class="desktop:margin-top-3 mobile:margin-bottom-4 margin-top-3 margin-bottom-2" markdown=0>
-    <a href="/assets/_pdfs/{{include.filename}}" download class="{% if titleLength >= 15 %} crt-page--downloadpdf-link {% else %} usa-button crt-page--downloadpdf-button {% endif %} text-bold">Download {{include.title}} PDF</a>
-  </div>
+<div class="mobile:margin-bottom-4 margin-bottom-2" markdown="0">
+  <a
+    href="/assets/_pdfs/{{include.filename}}"
+    download
+    class="usa-button crt-page--downloadpdf-button text-bold"
+    >Download PDF Guidance</a
+  >
+</div>

--- a/_includes/print-button.html
+++ b/_includes/print-button.html
@@ -1,3 +1,3 @@
-<div id="crt-page--printbutton--wrapper" class="desktop:margin-top-3 mobile:margin-bottom-4 width-card">
+<div id="crt-page--printbutton--wrapper" class="desktop:margin-top-3 margin-bottom-2 width-card">
   <button id="crt-page--printbutton" class="usa-button">Print this page</button>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,7 +16,7 @@ layout: default
         {% include print-button.html %}
       {% endif %}
       {% if page.sidenav-pdf.title and page.sidenav-pdf.filename %}
-        {% include download-pdf.html filename=page.sidenav-pdf.filename title=page.sidenav-pdf.title %}
+        {% include download-pdf.html filename=page.sidenav-pdf.filename %}
       {% endif %}
     </div>
     {% endif %}
@@ -27,7 +27,7 @@ layout: default
       {% if page.disclaimer %} {% include alert.html title="This is a test site. Do not rely on the
       information provided." text="This webpage is a prototype meant for user research. It has not
       undergone final review for legal accuracy and is not intended to provide legal guidance." %}
-      {% endif %} 
+      {% endif %}
       {% if page.ref!=nil %} {% include toggle-language.html %} {% endif %}
       <h1 id="top">{{page.title}}</h1>
       <div class="crt-landing--separator_small"></div>
@@ -51,11 +51,11 @@ layout: default
               >{{ page.publish-date | date: "%B %d, %Y"}}
             </time>
           </p>
-          {% endif %} 
+          {% endif %}
           {{page.lead | markdownify}}
         </div>
-        {% endif %} 
-        {{ content }} 
+        {% endif %}
+        {{ content }}
         {% if page.publish-date and page.updated-date %}
         <p class="text-thin font-sans-3xs">
           Originally issued:


### PR DESCRIPTION
[Github Issue](https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/512)

## What does this change?

The text content of the Download PDF button now reads: "Download PDF Guidance" and is styled as a button all the time rather than becoming a hyperlink at lengths of greater than 15 characters.

## Screenshots (for front-end PR):

Before:
<img width="477" alt="Screen Shot 2022-07-22 at 2 11 13 PM" src="https://user-images.githubusercontent.com/14644234/180499011-f67c0253-53ca-4346-8495-9e6af07a43dd.png">

After: 
<img width="463" alt="Screen Shot 2022-07-22 at 2 12 17 PM" src="https://user-images.githubusercontent.com/14644234/180499154-cea206ff-d827-4125-88f0-3640c5d9699f.png">

## Checklist:

+ [ ] Confirm the styling looks as expected
+ [ ] Confirm the button still downloads the pdfs

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
