### PR TITLE
Hide Open All Sections button on Print

### DIFF
--- a/_assets/css/custom/_print.scss
+++ b/_assets/css/custom/_print.scss
@@ -26,7 +26,7 @@
   .crt-menu--section,
   #crt-page--sidenav,
   #fba-button,
-  #expand-header-wrapper {
+  #crt-page--expandaccordions--wrapper {
     display: none !important;
   }
 }

--- a/_assets/css/custom/_print.scss
+++ b/_assets/css/custom/_print.scss
@@ -25,7 +25,8 @@
   .usa-menu-btn,
   .crt-menu--section,
   #crt-page--sidenav,
-  #fba-button {
+  #fba-button,
+  #expand-header-wrapper {
     display: none !important;
   }
 }


### PR DESCRIPTION
[Ticket](https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/509)

## What does this change?

Currently, when one attempts to print a page with the "Open all Sections" button present, the button appears on the printed page as well, even thought it is irrelevant to that view. This PR removes that button from the printed page.

## Screenshots (for front-end PR):

Not applicable.

## Checklist:

+ [ ] Attempt to print a page with an Open all Sections button on it: State and Local Governments, Frequently Asked Questions about Service Animals, or Business that are open to the public.
+ [ ] Confirm that both in the preview and in the printed document the Open all Sections button is not present, but that it is present on the page before and after printing.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.

