### PR TITLE
Hide COVID warning banner on print

### DIFF
--- a/_assets/css/custom/_print.scss
+++ b/_assets/css/custom/_print.scss
@@ -25,7 +25,8 @@
   .usa-menu-btn,
   .crt-menu--section,
   #crt-page--sidenav,
-  #fba-button {
+  #fba-button,
+  #warning-banner {
     display: none !important;
   }
 }

--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -1,7 +1,7 @@
 {% assign lang = "en" %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
-<div class="bg-warning padding-y-2 font-sans-2xs">
+<div id="warning-banner" class="bg-warning padding-y-2 font-sans-2xs">
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-12">


### PR DESCRIPTION
[Ticket](https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/516)

## What does this change?

Currently, when one attempts to print a page the COVID banner also prints. This banner is unhelpful on printed pages. This pull request hides the banner when printing a page.

## Screenshots (for front-end PR):

Not applicable.

## Checklist:

+ [ ] Attempt to print a page, confirm the COVID banner is not on the page.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.

