### PR TITLE
Hide background images of accordions when printing the page

### DIFF
--- a/_assets/css/custom/_print.scss
+++ b/_assets/css/custom/_print.scss
@@ -26,9 +26,15 @@
   .crt-menu--section,
   #crt-page--sidenav,
   #fba-button,
-  .usa-breadcrumb, 
+  .usa-breadcrumb,
   #warning-banner,
   #crt-page--expandaccordions--wrapper {
     display: none !important;
+  }
+
+  #crt-page--content .usa-accordion__button,
+  #crt-page--content .usa-accordion__button[aria-expanded="false"],
+  .usa-accordion__button {
+    background-image: none;
   }
 }


### PR DESCRIPTION
[Ticket](https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/511)

## What does this change?

The + and - icons on the accordion elements are not displayed properly when printing a page. This pull request changes the styling so the icons are not displayed at all when printing.

## Screenshots (for front-end PR):

Old:
<img width="472" alt="Screen Shot 2022-08-01 at 1 29 04 PM" src="https://user-images.githubusercontent.com/14644234/182207856-ad94eab7-aaae-4a8b-a517-00edba59a316.png">


New:
<img width="476" alt="Screen Shot 2022-08-01 at 1 29 29 PM" src="https://user-images.githubusercontent.com/14644234/182207880-48351883-ae63-4281-9777-96b347e947f5.png">


## Checklist:

+ [x] Attempt to print a page and confirm that the accordion elements don't have any + or - icons visable.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.

