### PR TITLE
Adding mobility devices and medical care to tags list to make JS work  on guidance page.

### DIFF
--- a/_assets/js/utils/constants.js
+++ b/_assets/js/utils/constants.js
@@ -11,7 +11,9 @@ const TAGS = [
   'web-access',
   'employment',
   'effective-communication',
-  'parking'
+  'parking',
+  'medical-care',
+  'mobility-devices'
 ];
 
 export { NUMBER_OF_RESULTS, SEARCH_ENDPOINT, ACCESS_KEY, AFFILIATE, TAGS };


### PR DESCRIPTION
The tags were not added to the constants.js file for mobility devices or medical care. They have been added so that filtering now works. 