### PR TITLE
Move Cases page to Enforcement

### DIFF
--- a/_assets/sass/custom/_header.scss
+++ b/_assets/sass/custom/_header.scss
@@ -119,5 +119,9 @@
   }
   .usa-nav__secondary {
     bottom: 0.75rem;
+
+    @media (min-width: 1024px) and (max-width: 1100px) {
+      min-width: 15rem;
+    }
   }
 }

--- a/_config.yml
+++ b/_config.yml
@@ -55,23 +55,30 @@ primary_navigation:
       en: "/"
       es: "/"
   - name:
-      en: Explore Featured Topics
-      en-short: Explore Topics
-      es: Explore Featured Topics
+      en: Featured Topics
+      en-short: Featured Topics
+      es: Featured Topics
     url:
       en: "/topics/"
       es: "/topics/"
   - name:
-      en: Review Laws, Regulations & Standards
-      en-short: Review Laws & Regulations
-      es: Review Laws, Regulations & Standards
+      en: Laws, Regulations & Standards
+      en-short: Laws & Regulations
+      es: Laws, Regulations & Standards
     url:
       en: "/law-and-regs/"
       es: "/law-and-regs/"
   - name:
-      en: View Guidance & Resource Materials
-      en-short: View Resources
-      es: View Guidance & Resource Materials
+      en: Guidance & Resource Materials
+      en-short: Resources
+      es: Guidance & Resource Materials
+    url:
+      en: "/resources/"
+      es: "/resources/"
+  - name:
+      en: Enforcement
+      en-short: Enforcement
+      es: Enforcement
     url:
       en: "/resources/"
       es: "/resources/"

--- a/_config.yml
+++ b/_config.yml
@@ -80,8 +80,8 @@ primary_navigation:
       en-short: Enforcement
       es: Enforcement
     url:
-      en: "/resources/"
-      es: "/resources/"
+      en: "/cases/"
+      es: "/cases/"
   - name:
       en: File a Complaint
       en-short: File a Complaint

--- a/_pages/cases.md
+++ b/_pages/cases.md
@@ -1,5 +1,5 @@
 ---
-title: Cases
+title: Enforcement
 description: "The Americans with Disabilities Act provides an important tool to fight discrimination: filing a complaint with an appropriate federal agency.  This page outlines the steps to get you started."
 permalink: /cases/
 redirect_from:
@@ -8,7 +8,7 @@ sidenav: false
 lead: |-
   The Department of Justice enforces the ADA through lawsuits and settlement agreements to achieve greater access, inclusion, and equal opportunity for people with disabilities.
 ---
-## Check Out Our Cases
+## Check Out Cases and Other Enforcement Matters
 
 **2021 - Present**
 

--- a/_pages/cases.md
+++ b/_pages/cases.md
@@ -1,12 +1,14 @@
 ---
 title: Cases
 description: "The Americans with Disabilities Act provides an important tool to fight discrimination: filing a complaint with an appropriate federal agency.  This page outlines the steps to get you started."
-permalink: /law-and-regs/cases/
+permalink: /cases/
+redirect_from:
+  - /law-and-regs/cases/
 sidenav: false
 lead: |-
   The Department of Justice enforces the ADA through lawsuits and settlement agreements to achieve greater access, inclusion, and equal opportunity for people with disabilities.
 ---
-## Check Out Our Cases  
+## Check Out Our Cases
 
 **2021 - Present**
 
@@ -16,26 +18,26 @@ Go to our cases page on [justice.gov/CRT](https://www.justice.gov/crt/disability
 
 Go to our cases page on [ADA.gov](http://www.ada.gov/enforce_current.htm)
 
-## Enforcing the ADA  
+## Enforcing the ADA
 
 Broadly speaking, our ADA cases involve:
 
 - Employment (Title I)
 - State and local governments’ services, programs, and activities (Title II)
-- Businesses and nonprofits open to the public (Title III)  
+- Businesses and nonprofits open to the public (Title III)
 
 Our matters are both large and small.  For example, we might work on a nationwide case affecting hundreds of people or a case involving one child in one school.
 
-Our matters also cover a range of disability rights issues and contexts, such as:  
+Our matters also cover a range of disability rights issues and contexts, such as:
 
-- Communication with people with disabilities  
-- Criminal justice  
-- Education  
+- Communication with people with disabilities
+- Criminal justice
+- Education
 - Employment
 - Health care
 - Physical accessibility
-- Segregation of people with disabilities (also known as Olmstead work)  
-- Service animals  
-- Technology  
-- Transportation  
+- Segregation of people with disabilities (also known as Olmstead work)
+- Service animals
+- Technology
+- Transportation
 - Voting

--- a/_pages/law-and-regs/index.md
+++ b/_pages/law-and-regs/index.md
@@ -21,36 +21,36 @@ disabilities in many aspects of public life.
 
 Learn more about the ADA on our [Introduction to the ADA page]( {{'/topics/intro-to-ada'| relative_url}}).
 
-## ADA Regulations  
+## ADA Regulations
 
-DOJ is responsible for issuing regulations under Titles II and III of the Americans with Disabilities Act (ADA) that explain the rights of people with disabilities and the obligations of those covered by the law.  
+DOJ is responsible for issuing regulations under Titles II and III of the Americans with Disabilities Act (ADA) that explain the rights of people with disabilities and the obligations of those covered by the law.
 
-- For more information about the ADA generally, check out [Introduction to the Americans with Disabilities Act]( {{'/topics/intro-to-ada' | relative_url}}).  
-- For more information about Title II of the ADA, see [State and Local Governments]( {{'/topics/title-ii' | relative_url}}).  
-- For more information about Title III of the ADA, see [Businesses That Are Open to the Public]( {{'/topics/title-iii' | relative_url}}).  
+- For more information about the ADA generally, check out [Introduction to the Americans with Disabilities Act]( {{'/topics/intro-to-ada' | relative_url}}).
+- For more information about Title II of the ADA, see [State and Local Governments]( {{'/topics/title-ii' | relative_url}}).
+- For more information about Title III of the ADA, see [Businesses That Are Open to the Public]( {{'/topics/title-iii' | relative_url}}).
 
-{% details What is a regulation? %}  
-A regulation (also called a "rule") is a set of requirements issued by a federal agency to implement laws passed by Congress.  When Congress passes laws, many details are often left to federal agencies to flesh out in regulations.  For example, when Congress passed the ADA, it gave DOJ the authority to issue regulations that explain the rights and obligations under Titles II and III of the ADA.  
-{% enddetails %}  
+{% details What is a regulation? %}
+A regulation (also called a "rule") is a set of requirements issued by a federal agency to implement laws passed by Congress.  When Congress passes laws, many details are often left to federal agencies to flesh out in regulations.  For example, when Congress passed the ADA, it gave DOJ the authority to issue regulations that explain the rights and obligations under Titles II and III of the ADA.
+{% enddetails %}
 
 Check out DOJ’s current ADA regulations:
 
-- [Title II](https://www.ada.gov/regs2010/titleII_2010/title_ii_primer.html) (State and Local Governments)  
-- [Title III](https://www.ada.gov/regs2010/titleIII_2010/titleIII_2010_regulations.htm) (Public Accommodations and Commercial Facilities)  
+- [Title II](https://www.ada.gov/regs2010/titleII_2010/title_ii_primer.html) (State and Local Governments)
+- [Title III](https://www.ada.gov/regs2010/titleIII_2010/titleIII_2010_regulations.htm) (Public Accommodations and Commercial Facilities)
 
-In the [Spring 2022 Unified Agenda](https://www.reginfo.gov/public/do/eAgendaMain), DOJ announced that it plans to issue new ADA regulations on the following topics:  
+In the [Spring 2022 Unified Agenda](https://www.reginfo.gov/public/do/eAgendaMain), DOJ announced that it plans to issue new ADA regulations on the following topics:
 
-- [Medical Diagnostic Equipment](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA78) (Titles II and III)  
-- [Website Accessibility](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA79) (Title II)  
-- [The Public Right-of-Way](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA77) (Title II)  
-- [Equipment and Furniture](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA76) (Titles II and III)  
+- [Medical Diagnostic Equipment](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA78) (Titles II and III)
+- [Website Accessibility](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA79) (Title II)
+- [The Public Right-of-Way](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA77) (Title II)
+- [Equipment and Furniture](https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202204&RIN=1190-AA76) (Titles II and III)
 
-{% details What is the Unified Agenda? %}  
-The [Unified Agenda](https://www.reginfo.gov/public/jsp/eAgenda/UA_About.myjsp) provides information about federal agencies’ regulatory priorities and the specific regulations that they plan to issue in the short and long term.  
-{% enddetails %}  
+{% details What is the Unified Agenda? %}
+The [Unified Agenda](https://www.reginfo.gov/public/jsp/eAgenda/UA_About.myjsp) provides information about federal agencies’ regulatory priorities and the specific regulations that they plan to issue in the short and long term.
+{% enddetails %}
 
-## Cases
+<!-- ## Cases
 
 The Department of Justice enforces the ADA through lawsuits and settlement agreements to achieve greater access, inclusion, and equal opportunity for people with disabilities.
 
-[View the Cases page]( {{'/law-and-regs/cases' | relative_url}})
+[View the Cases page]( {{'/cases' | relative_url}}) -->


### PR DESCRIPTION
### What does this change?

1. Moved the /cases page from under /law-and-regs to top level
2. Added new Nav item - Enforcement that points to /cases
3. Changed H1 on /cases page
4. Changed short title of Featured Topics
5. Cut size of search bar down
6. Removed verbs from the titles in the main nav