### PR TITLE
New markdown widget for creating html figures

### DIFF
--- a/_assets/js/utils/constants.js
+++ b/_assets/js/utils/constants.js
@@ -13,7 +13,8 @@ const TAGS = [
   'effective-communication',
   'parking',
   'medical-care',
-  'mobility-devices'
+  'mobility-devices',
+  'child-care'
 ];
 
 export { NUMBER_OF_RESULTS, SEARCH_ENDPOINT, ACCESS_KEY, AFFILIATE, TAGS };

--- a/_plugins/figures.rb
+++ b/_plugins/figures.rb
@@ -1,0 +1,47 @@
+module Jekyll
+    class FigureTag < Liquid::Block
+      def initialize(tag_name, block_options, liquid_options)
+        super
+        @figureID = "#{block_options.downcase.strip.gsub(/\W/,'')}"
+        @title = block_options
+      end
+
+      def render(context)
+        context.stack do
+          context["figureID"] = @figureID
+          @content = super
+        end
+        output = <<~EOS
+            <figure id=#{@figureID} markdown=0 >
+                <strong>#{@title}</strong><br/>
+                #{@content}
+            </figure>
+        EOS
+
+        output
+      end
+    end
+
+    class FigCaptionTag < Liquid::Block
+      def initialize(tag_name, block_options, liquid_options)
+        super
+      end
+
+      def render(context)
+        context.stack do
+          @content = super
+        end
+        output = <<~EOS
+          <figcaption>
+          #{@content}
+          </figcaption>
+        EOS
+
+        output
+      end
+    end
+
+  end
+
+  Liquid::Template.register_tag('figure', Jekyll::FigureTag)
+  Liquid::Template.register_tag('figcaption', Jekyll::FigCaptionTag)


### PR DESCRIPTION
### What does this change?

This adds a new mark down widget that allows users to add in figures and figure captions.
You can still add figures using standard HTML. But this syntax is a little shorter. 
To use it:

{% figure %}
This can be whatever figure content you want. Add images like so:
{% assets path-to-image alt="alt text" %}
{% endfigure %}

If you want to add a caption, do it like so:

{% figure %}
This can be whatever figure content you want. Add images like so:
{% assets path-to-image alt="alt text" %}
{% figcaption %}
Some text!
{% endfigcaption %}
{% endfigure %}

If you want to add a title to your figure, add it like this:

{% figure MyTitle %}
This can be whatever figure content you want. Add images like so:
{% assets path-to-image alt="alt text" %}
{% figcaption %}
Some text!
{% endfigcaption %}
{% endfigure %}