### PR TITLE
Fixing left alignment of text on feedback page

### DIFF
--- a/_assets/sass/custom/_touchpoints.scss
+++ b/_assets/sass/custom/_touchpoints.scss
@@ -22,13 +22,13 @@
   .wrapper {
     padding: 0px !important;
   }
-  
+
   .questions input,
   .questions textarea {
-    border: solid 1px #767676 !important; 
+    border: solid 1px #767676 !important;
     border-radius: 4px !important;
   }
-  
+
   #fba-modal-title,
   .fba-instructions,
   hr {
@@ -39,17 +39,18 @@
     margin-left: 0px !important;
     padding-left: 0px !important;
   }
-  
+
   .usa-label[for=answer_01] {
     margin-top: 0px !important;
   }
-  
+
   .usa-banner {
     background-color: #fff !important;
   }
-  
+
   .usa-banner__inner {
     padding-left: 0px !important;
+    max-width: 100% !important;
   }
 
   .usa-button{
@@ -61,7 +62,7 @@
       background-color: color($theme-link-hover-color) !important;
     }
   }
-  
+
   .usa-alert {
     padding-top: 0px !important;
   }


### PR DESCRIPTION
Super small alignment fix for the text on the Feedback page. 

How it used to look:

![Screenshot 2022-10-20 at 10-50-07 Give Us Feedback](https://user-images.githubusercontent.com/14644234/196982536-acca76f3-d7e3-49fe-932e-363b1966f3f8.png)

How it looks now:

![Screenshot 2022-10-20 at 10-52-27 Give Us Feedback](https://user-images.githubusercontent.com/14644234/196983139-be848657-ed0e-4dce-b9c7-01a42e4b4192.png)


