### PR TITLE
Updating Search button to include the text "Search"

### DIFF
--- a/_assets/sass/custom/_search.scss
+++ b/_assets/sass/custom/_search.scss
@@ -12,17 +12,24 @@
   background-size: 1.5rem;
 }
 
-.shrink-search {
-  min-width: 2rem !important;
-  right: 1rem !important;
-  max-width: 27ch !important;
-}
-
 label.usa-sr-only {
   color: white;
 }
 
+@include at-media(mobile) {
+
+  .usa-search--small [type="submit"],
+  .usa-search--small .usa-search__submit {
+    min-width: 5rem !important;
+  }
+}
+
 @include at-media(desktop) {
+
+  input#query {
+    max-width: 20ch !important;
+  }
+
   .usa-search--small input[type="search"] {
     border-color: color("white");
   }
@@ -30,7 +37,8 @@ label.usa-sr-only {
   .usa-search--small [type="submit"],
   .usa-search--small .usa-search__submit {
     background-color: color($theme-color-base-lighter);
-    background-image: url("./images/search.svg");
+    color: color($theme-color-primary-darker);
+    min-width: 5rem !important;
 
     &:hover {
       background-color: color("gray-cool-20");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,5 @@
 {% include skipnav.html %} {% include banner.html %} {% if site.beta %} {%include banner-beta.html
-%} {% endif %} {% assign lang = page.lang %} {% if lang==nil %}{% assign lang="en" %}{% endif %} {%
-assign shrink = "" %} {% unless lang=="en" %} {% assign shrink = "shrink-search" %} {% endunless %}
+%} {% endif %} {% assign lang = page.lang %} {% if lang==nil %}{% assign lang="en" %}{% endif %}
 <header class="usa-header usa-header--extended">
   <div class="crt-landing--header crt-lightblue height-card">
     <div class="usa-navbar position-relative border-bottom-0">

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -47,9 +47,7 @@
       autocomplete="off"
     />
     <button class="usa-button radius-right-lg" type="submit">
-      <!-- {% asset img/usa-icons-bg/search--white.svg class="desktop:display-none" alt="{{site.data[lang]['i18n'].aria.search}}" %} -->
       Search
-      <!-- <span class="usa-sr-only">Search Beta.ADA.gov</span> -->
     </button>
   </form>
   {% endif %}

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -47,8 +47,9 @@
       autocomplete="off"
     />
     <button class="usa-button radius-right-lg" type="submit">
-      {% asset img/usa-icons-bg/search--white.svg class="desktop:display-none" alt="{{site.data[lang]['i18n'].aria.search}}" %}
-      <span class="usa-sr-only">Search Beta.ADA.gov</span>
+      <!-- {% asset img/usa-icons-bg/search--white.svg class="desktop:display-none" alt="{{site.data[lang]['i18n'].aria.search}}" %} -->
+      Search
+      <!-- <span class="usa-sr-only">Search Beta.ADA.gov</span> -->
     </button>
   </form>
   {% endif %}


### PR DESCRIPTION
Reason: The search icon is currently a bit ambiguous, and it's meaning is not clear.
By explicitly stating 'Search' in the search bar, we hope to remove any ambiguity about the button's function.