### PR TITLE
Covid page moved to resources page

### DIFF
--- a/_assets/js/templates/badges/badgeTemplate.js
+++ b/_assets/js/templates/badges/badgeTemplate.js
@@ -1,8 +1,8 @@
 export default function badge(title) {
-    const normalizedTitle = title.split('-').join(" ");
+    const normalizedTitle = title === 'covid-19' ? title.toUpperCase() : title.split('-').join(" ")[0].toUpperCase() + title.split('-').join(" ").substring(1);
     return `
     <span class="usa-button text-normal button-wrapper">
-     ${normalizedTitle[0].toUpperCase() + normalizedTitle.substring(1)}
+     ${normalizedTitle}
     <button class="usa-button usa-button--unstyled text-no-underline"
     >
     <span class="margin-left-05 flex-align-center"><svg fill='#162e51' aria-hidden="true" role="img">

--- a/_assets/js/utils/constants.js
+++ b/_assets/js/utils/constants.js
@@ -14,7 +14,8 @@ const TAGS = [
   'parking',
   'medical-care',
   'mobility-devices',
-  'child-care'
+  'child-care',
+  'covid-19'
 ];
 
 export { NUMBER_OF_RESULTS, SEARCH_ENDPOINT, ACCESS_KEY, AFFILIATE, TAGS };

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,6 +1,7 @@
 allowed-tags:
   - artificial intelligence
   - child care
+  - covid-19
   - effective communication
   - employment
   - medical care

--- a/_includes/category-selector.html
+++ b/_includes/category-selector.html
@@ -40,7 +40,13 @@
                 data-checked="false"
               />
               <label class="usa-checkbox__label" for="{{tag | replace: ' ', '-'}}"
-                >{{tag | capitalize}}</label
+                >
+                  {% if tag == 'covid-19' %}
+                    {{ tag | upcase }}
+                  {% else %}
+                    {{tag | capitalize}}
+                  {% endif %}
+                  </label
               >
             </div>
           </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
   </noscript>
   {% include header.html %}
   <main id="main-content" class="margin-top-0 margin-bottom-0">
-    {% include notice.html %}
+    <!-- {% include notice.html %} -->
     {{ content }}
   </main>
   {% include footer.html %}

--- a/_pages/_resources/2021-08-25-covid-qa.md
+++ b/_pages/_resources/2021-08-25-covid-qa.md
@@ -2,9 +2,12 @@
 
 title:  COVID-19 and the Americans with Disabilities Act
 title_es: El COVID-19 y la ley de Estadounidenses con Discapacidades
+description: COVID-19 and the Americans with Disabilities Act &mdash;view information about streateries and medical setting visitor policies.
 notice_text: COVID-19 and the Americans with Disabilities Act &mdash;view information about streateries and medical setting visitor policies
 notice_text_es: El COVID-19 y la ley de Estadounidenses con Discapacidades &mdash; visualizar información sobre políticas para visitantes a entornos médicos y restaurantes en la calle
-
+redirect_from: /notices/2021/08/25/covid-qa/
+tags:
+- covid-19
 ---
 
 *“As a Nation, we cannot adequately respond to, and recover from, COVID-19 if we do not protect all of our neighbors. Civil rights protections and responsibilities still apply, even during emergencies. They cannot be waived.”*
@@ -145,7 +148,7 @@ EXAMPLE: A store sets up a curbside pickup booth, blocking the designated access
 
 ## Learn more about the Civil Rights Division’s disability response to Coronavirus
 
-[Department of Justice Fact Sheet: Accessibility of COVID-19 Vaccine Websites and the Americans with Disabilities Act](https://www.ada.gov/fact_sheet_vaccine_website_enforcement.pdf) (5/11/22)  
+[Department of Justice Fact Sheet: Accessibility of COVID-19 Vaccine Websites and the Americans with Disabilities Act](https://www.ada.gov/fact_sheet_vaccine_website_enforcement.pdf) (5/11/22)
 
 [Departments of Justice and Education Issue Guidance on Supporting and Protecting Rights of Students with Mental Health Disabilities in Era of COVID-19](https://www.ada.gov/students_self-harm_fact_sheet.pdf)  (10/13/21)
 


### PR DESCRIPTION
Addresses concern in this ticket: https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/607

Changes:

1. Moved the COVID 19 notification to under /resources
2. Added COVID-19 filter
3. Added page description to COVID 19 page
4. Added redirect to COVID 19 page
5. Removed COVID 19 banner