### PR TITLE
Change is coming messaging

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -7,7 +7,7 @@
   </svg>
   <ol class="padding-left-1" vocab="http://schema.org/"
   typeof="BreadcrumbList" class="usa-breadcrumb__list">
-    {% assign crumbs = page.url | remove:'/index.html' | remove:'/es' | remove: '/notices' | remove: '/2021' | remove: '/08' | remove: '/25' | split: '/' %}
+    {% assign crumbs = page.url | remove:'/index.html' | remove:'/es' | remove: '/notices' | remove: '/2022' | remove: '/11' | remove: '/02' | split: '/' %}
     <li property="itemListElement"
     typeof="ListItem" class="usa-breadcrumb__list-item"><a property="item"
     typeof="WebPage" href="/"><span property="name">{{ site.primary_navigation[0].name[lang] }}</span></a><meta property="position" content="1" /></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
   </noscript>
   {% include header.html %}
   <main id="main-content" class="margin-top-0 margin-bottom-0">
-    <!-- {% include notice.html %} -->
+    {% include notice.html %}
     {{ content }}
   </main>
   {% include footer.html %}

--- a/_pages/notices/_posts/2022-11-02-upcoming-changes.md
+++ b/_pages/notices/_posts/2022-11-02-upcoming-changes.md
@@ -2,8 +2,8 @@
 
 title: The New ADA.gov
 title_es: The New ADA.gov
-notice_text: In the coming weeks this site will become ADA.gov. Learn more about what to expect.
-notice_text_es: In the coming weeks this site will become ADA.gov. Learn more about what to expect.
+notice_text: Soon the beta site will become the new ADA.gov. Learn more about what to expect.
+notice_text_es:  Soon the beta site will become the new ADA.gov. Learn more about what to expect.
 
 ---
 

--- a/_pages/notices/_posts/2022-11-02-upcoming-changes.md
+++ b/_pages/notices/_posts/2022-11-02-upcoming-changes.md
@@ -1,27 +1,17 @@
 ---
-
-title: The New ADA.gov
-title_es: The New ADA.gov
-notice_text: Soon the beta site will become the new ADA.gov. Learn more about what to expect.
-notice_text_es:  Soon the beta site will become the new ADA.gov. Learn more about what to expect.
-
+title: Upcoming changes to ADA.gov
+title_es: Upcoming changes to ADA.gov
+notice_text: Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect
+notice_text_es:  Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect
 ---
 
-In the coming weeks, the Department will be launching a new and improved version of ADA.gov.
+Soon the Department will be launching a new and improved version of ADA.gov.
 
-## What’s different?
+## What do these changes mean for users of the ADA sites?
 
-The new and improved ADA.gov is:
+- When users go to ADA.gov they will see the new and improve site.
+- The former ADA.gov site will be available at archive.ADA.gov. Archiving the former site simply means that the site will no longer be updated.
 
-- Modern with easy to use navigation tools
-- User-centered and written in plain-language (less legal jargon)
-- Mobile compatible, so it can be used across all devices
+## What's different about the new ADA.gov?
 
-## What to expect?
-
-In the coming weeks you can expect to see:
-
-- Content currently on ADA.gov will be moved to archive.ADA.gov
-- Content on beta.ADA.gov will be moved to ADA.gov
-
-Our work is not done, we will continue to expand the content available on ADA.gov.
+The updated version of ADA.gov is designed to better serve the public and help expand access for people with disabilities. With modern easy-to-use navigation tools, user-centered design, content written in plain-language (less legal jargon) and is mobile compatible.

--- a/_pages/notices/_posts/2022-11-02-upcoming-changes.md
+++ b/_pages/notices/_posts/2022-11-02-upcoming-changes.md
@@ -1,0 +1,27 @@
+---
+
+title: The New ADA.gov
+title_es: The New ADA.gov
+notice_text: In the coming weeks this site will become ADA.gov. Learn more about what to expect.
+notice_text_es: In the coming weeks this site will become ADA.gov. Learn more about what to expect.
+
+---
+
+In the coming weeks, the Department will be launching a new and improved version of ADA.gov.
+
+## What’s different?
+
+The new and improved ADA.gov is:
+
+- Modern with easy to use navigation tools
+- User-centered and written in plain-language (less legal jargon)
+- Mobile compatible, so it can be used across all devices
+
+## What to expect?
+
+In the coming weeks you can expect to see:
+
+- Content currently on ADA.gov will be moved to archive.ADA.gov
+- Content on beta.ADA.gov will be moved to ADA.gov
+
+Our work is not done, we will continue to expand the content available on ADA.gov.

--- a/_pages/notices/_posts/2022-11-02-upcoming-changes.md
+++ b/_pages/notices/_posts/2022-11-02-upcoming-changes.md
@@ -9,7 +9,7 @@ Soon the Department will be launching a new and improved version of ADA.gov.
 
 ## What do these changes mean for users of the ADA sites?
 
-- When users go to ADA.gov they will see the new and improve site.
+- When users go to ADA.gov they will see the new and improved site.
 - The former ADA.gov site will be available at archive.ADA.gov. Archiving the former site simply means that the site will no longer be updated.
 
 ## What's different about the new ADA.gov?

--- a/_pages/notices/_posts/2022-11-02-upcoming-changes.md
+++ b/_pages/notices/_posts/2022-11-02-upcoming-changes.md
@@ -1,8 +1,8 @@
 ---
 title: Upcoming changes to ADA.gov
 title_es: Upcoming changes to ADA.gov
-notice_text: Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect
-notice_text_es:  Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect
+notice_text: Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect.
+notice_text_es:  Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect.
 ---
 
 Soon the Department will be launching a new and improved version of ADA.gov.


### PR DESCRIPTION
Changes:

1. Updated banner notice to read: "Soon beta.ADA.gov will become the new ADA.gov. Learn what to expect"
2. Added a new page titled "Upcoming changes to ADA.gov" to help explain upcoming changes to the site.
3. Updated the breadcrumbs component to hide unneeded month, date and year links.