### PR TITLE
Bump Nokogiri to 1.13.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
     minitest (5.14.4)
-    nokogiri (1.13.6)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pathutil (0.16.2)


### PR DESCRIPTION
Addressing dependabot issue. 

Upgrading nokogiri version from 1.13.6 to 1.13.9