### PR TITLE
Fixing minor alignment issue of list items

### DIFF
--- a/_includes/landing/learn.html
+++ b/_includes/landing/learn.html
@@ -32,7 +32,7 @@
                   <p>
                     Examples:
                   </p>
-                  <ul>
+                  <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
                         <a class="text-white" href="{{example.link | relative_url }}">

--- a/_includes/landing/service-animals.html
+++ b/_includes/landing/service-animals.html
@@ -32,7 +32,7 @@
                   <p>
                     Examples:
                   </p>
-                  <ul>
+                  <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
                         <a href="{{example.link | relative_url }}">


### PR DESCRIPTION
Alignment of list items on homepage deviated from original design mocks. This has been fixed in this PR.

Note the alignment in the Design mocks:

<img width="192" alt="Screen Shot 2022-11-14 at 2 58 30 PM" src="https://user-images.githubusercontent.com/14644234/201754089-0b9342a0-0c72-4928-a783-5e71f2221895.png">


Note the current alignment:
<img width="373" alt="Screen Shot 2022-11-14 at 2 58 42 PM" src="https://user-images.githubusercontent.com/14644234/201754129-cf078e08-5873-458d-8500-a973b9dfa504.png">


And here is the fixed alignment:

<img width="374" alt="Screen Shot 2022-11-14 at 2 59 58 PM" src="https://user-images.githubusercontent.com/14644234/201754247-ff9d0482-09df-4f0d-b6c5-d962be1d6ed1.png">
