### PR TITLE
Updating search params to remove beta search

### DIFF
--- a/_assets/js/utils/constants.js
+++ b/_assets/js/utils/constants.js
@@ -1,8 +1,8 @@
 // Pagination Constants:
 const NUMBER_OF_RESULTS = 20;
 const SEARCH_ENDPOINT = 'https://search.usa.gov/api/v2/search/i14y';
-const ACCESS_KEY = 'R9JA5YunOBaTGydUNm-oJjGCqKQ-zXsulsNskJVe5-c=';
-const AFFILIATE = 'justice-ada-beta';
+const ACCESS_KEY = 'Z8vERzCYuVMzAh2CKIRiyj1tRbOhdzseBGOuirGz1AQ=';
+const AFFILIATE = 'justice-ada';
 const TAGS = [
   'artificial-intelligence',
   'service-animals',

--- a/_config.yml
+++ b/_config.yml
@@ -124,10 +124,10 @@ searchgov:
   endpoint: https://search.usa.gov
 
   # replace this with your search.gov account
-  affiliate: justice-ada-beta
+  affiliate: justice-ada
 
   # replace with your access key
-  access_key: R9JA5YunOBaTGydUNm-oJjGCqKQ-zXsulsNskJVe5-c=
+  access_key: Z8vERzCYuVMzAh2CKIRiyj1tRbOhdzseBGOuirGz1AQ=
 
   # this renders the results within the page instead of sending to user to search.gov
   inline: true


### PR DESCRIPTION
Changes:
1. Updated search params in the config.yml file
2. Updated search params in the constants.js file

Both of these changes handle the initial search and then the search pagination.

Search.gov has fully indexed each site (ada.gov and archive.ada.gov). 