### PR TITLE
Change search sort from relevance to date [WIP]

### DIFF
--- a/_assets/js/pagination.js
+++ b/_assets/js/pagination.js
@@ -11,6 +11,7 @@ let searchParams = {
   query: urlParams.get('query'),
   offset: urlParams.get('offset') || 0,
   limit: NUMBER_OF_RESULTS,
+  sort_by: 'date'
 };
 // Add our total number of results DOM node:
 const target = document.getElementById("totalResultsTarget");

--- a/_config.yml
+++ b/_config.yml
@@ -132,6 +132,8 @@ searchgov:
   # this renders the results within the page instead of sending to user to search.gov
   inline: true
 
+  sort_by: date
+
   # how many results to display per pages
   limit: 20
 ##########################################################################################


### PR DESCRIPTION
Changes: 
1. Search results are now prioritized by date rather than 'relevance'.

This is for testing purposes.