### PR TITLE
Adding click tracking to search results

### DIFF
--- a/_assets/js/click-tracking.js
+++ b/_assets/js/click-tracking.js
@@ -10,7 +10,7 @@ export default function clickTracking() {
   allLinks.forEach((link, index) => {
     const url = link.href;
     const query = encodeURI(getSearchParam('query'));
-    const position = Number(getSearchParam('offset')) + (index + 1);
+    const position = encodeURI(Number(getSearchParam('offset')) + (index + 1));
     // What we need to send to the click tracking endpoint:
     // url clicked
     // search query

--- a/_assets/js/click-tracking.js
+++ b/_assets/js/click-tracking.js
@@ -1,5 +1,6 @@
 // Import our constants from constandts.js
 import { CLICK_TRACKING_ENDPOINT, ACCESS_KEY, AFFILIATE, MODULE_CODE } from './utils/constants';
+import { getSearchParam } from './utils/searchParamUtils';
 
 export default function clickTracking() {
   // Get all the anchor tags that are children of b tags on the page:
@@ -8,16 +9,8 @@ export default function clickTracking() {
   // Loop through all the links and add a click event listener to each one:
   allLinks.forEach((link, index) => {
     const url = link.href;
-    const query = location.search.split('&').find((param) => param.startsWith('query='));
-    const position = location.search.split('&').includes('offset=') ?
-    Number(
-        location.search
-          .split('&')
-          .find((param) => param.startsWith('offset='))
-          .replace('offset=', '')
-      ) +
-      index +
-      1 : index + 1;
+    const query = encodeURI(getSearchParam('query'));
+    const position = Number(getSearchParam('offset')) + (index + 1);
     // What we need to send to the click tracking endpoint:
     // url clicked
     // search query
@@ -28,16 +21,13 @@ export default function clickTracking() {
     const endpoint = `${CLICK_TRACKING_ENDPOINT}?url=${url}&affiliate=${AFFILIATE}&access_key=${ACCESS_KEY}&module_code=${MODULE_CODE}&${query}&position=${position}`;
     // When a link is clicked, send a POST request to the search endpoint:
     link.addEventListener('click', () => {
-      fetch(
-        endpoint,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Content-length': 0,
-          },
-        }
-      );
+      fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-length': 0,
+        },
+      });
     });
   });
 }

--- a/_assets/js/click-tracking.js
+++ b/_assets/js/click-tracking.js
@@ -1,0 +1,43 @@
+// Import our constants from constandts.js
+import { CLICK_TRACKING_ENDPOINT, ACCESS_KEY, AFFILIATE, MODULE_CODE } from './utils/constants';
+
+export default function clickTracking() {
+  // Get all the anchor tags that are children of b tags on the page:
+  const allLinks = document.querySelectorAll('.search-result');
+
+  // Loop through all the links and add a click event listener to each one:
+  allLinks.forEach((link, index) => {
+    const url = link.href;
+    const query = location.search.split('&').find((param) => param.startsWith('query='));
+    const position = location.search.split('&').includes('offset=') ?
+    Number(
+        location.search
+          .split('&')
+          .find((param) => param.startsWith('offset='))
+          .replace('offset=', '')
+      ) +
+      index +
+      1 : index + 1;
+    // What we need to send to the click tracking endpoint:
+    // url clicked
+    // search query
+    // affiliate
+    // position
+    // module code
+    // access key
+    const endpoint = `${CLICK_TRACKING_ENDPOINT}?url=${url}&affiliate=${AFFILIATE}&access_key=${ACCESS_KEY}&module_code=${MODULE_CODE}&${query}&position=${position}`;
+    // When a link is clicked, send a POST request to the search endpoint:
+    link.addEventListener('click', () => {
+      fetch(
+        endpoint,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-length': 0,
+          },
+        }
+      );
+    });
+  });
+}

--- a/_assets/js/templates/search/searchResultsTemplate.js
+++ b/_assets/js/templates/search/searchResultsTemplate.js
@@ -1,7 +1,7 @@
 export default function searchResultsTemplate(content) {
   return `
         <li class="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest">
-        <b class="title"><a href="${content.url}">${content.title
+        <b class="title"><a class='search-result' href="${content.url}">${content.title
           .replace(/\uE000/g, '<span class="bg-yellow">')
           .replace(/\uE001/g, "</span>")}</a></b>
       <div class="text-base content-url"> ${content.url} </div>

--- a/_assets/js/utils/constants.js
+++ b/_assets/js/utils/constants.js
@@ -1,8 +1,10 @@
 // Pagination Constants:
 const NUMBER_OF_RESULTS = 20;
 const SEARCH_ENDPOINT = 'https://search.usa.gov/api/v2/search/i14y';
+const CLICK_TRACKING_ENDPOINT = 'https://api.gsa.gov/technology/searchgov/v2/clicks/';
 const ACCESS_KEY = 'Z8vERzCYuVMzAh2CKIRiyj1tRbOhdzseBGOuirGz1AQ=';
 const AFFILIATE = 'justice-ada';
+const MODULE_CODE = 'I14Y';
 const TAGS = [
   'artificial-intelligence',
   'service-animals',
@@ -18,4 +20,4 @@ const TAGS = [
   'covid-19'
 ];
 
-export { NUMBER_OF_RESULTS, SEARCH_ENDPOINT, ACCESS_KEY, AFFILIATE, TAGS };
+export { NUMBER_OF_RESULTS, SEARCH_ENDPOINT, CLICK_TRACKING_ENDPOINT, ACCESS_KEY, AFFILIATE, MODULE_CODE,TAGS };

--- a/_assets/js/utils/renderSearchPage.js
+++ b/_assets/js/utils/renderSearchPage.js
@@ -7,6 +7,7 @@ import paginationTemplate from "../templates/pagination/paginationTemplate";
 import textBestBetsTemplate from "../templates/search/textBestBetsTemplate";
 import searchResultsTemplate from "../templates/search/searchResultsTemplate";
 import totalResults from "../templates/search/totalResultsTemplate";
+import clickTracking from "../click-tracking";
 
 export default function renderSearchPage(searchResults, urlParams, numberOfResults) {
   const results = searchResults;
@@ -38,6 +39,8 @@ export default function renderSearchPage(searchResults, urlParams, numberOfResul
     webResults.forEach(function (item) {
       renderSearchResults(searchResultsTemplate(item));
     });
+    // Set up click tracking for search.gov:
+    clickTracking();
     // List the total number of results:
     target.innerHTML = totalResults(webTotalResults, 'result');
     // FOR PAGINATION:

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -18,7 +18,9 @@
 
 {% endif %} {% asset vendor/uswds/uswds.min.js !type %} {% asset dist/main-compiled.js !type %} {%
 asset dist/accordion-compiled.js !type %} {% if page.title == 'Search' %} {% asset
-dist/pagination-compiled.js !type %} {% endif %} {% if page.title == 'Give Us Feedback' %}
+dist/pagination-compiled.js !type %}
+{% asset dist/clickTracking-compiled.js %}
+{% endif %} {% if page.title == 'Give Us Feedback' %}
 <script src="https://touchpoints.app.cloud.gov/touchpoints/73c5715c.js" async></script>
 {% endif %} {% if page.title == 'View Guidance & Resource Materials'%} {% asset
 dist/taResources-compiled.js %} {% endif %} {% unless page.back-to-top == nil or page.back-to-top ==

--- a/_pages/search.md
+++ b/_pages/search.md
@@ -6,7 +6,6 @@ sidenav: false
 redirect_from:
   - /search.htm
 ---
-{% include search-dust-text.html %}
 {% if site.searchgov %}
 <div tabindex='0' id="totalResultsTarget" class="margin-y-1"></div>
 <ol id="search-results" class="add-list-reset"></ol>

--- a/webpack.javascript.js
+++ b/webpack.javascript.js
@@ -7,7 +7,8 @@ module.exports = {
     main: "./_assets/js/main.js",
     pagination: './_assets/js/pagination.js',
     taResources: './_assets/js/ta-selectors.js',
-    backToTop: './_assets/js/utils/backToTop.js'
+    backToTop: './_assets/js/utils/backToTop.js',
+    clickTracking: './_assets/js/click-tracking.js'
   },
   output: {
     path: path.resolve(__dirname, './_assets/js/', 'dist'),


### PR DESCRIPTION
What's changed?

We're adding click tracking to our search results so we can update search.gov with popularity scores for our search results.

This adds an onclick event for each link on the search results page and sends the following info to Search.gov:
- url clicked
- search query
- affiliate
- position
- module code
- access key

We aren't doing anything with the response at the moment.

No front-end design changes. 

To test: 
1. Fire up locally
2. Let me know so I open the search.gov click tracking admin console
3. Enter a search query
4. Check the console to make sure there are no errors logged
5. Click a link
6. Let me (Jack Ryan) know 
7. I'll confirm that the number of clicks listed in the admin console has increased by the number of links you've opened