### PR TITLE
Downgrade Ubuntu version in a11y action to 20.04

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Ruby Dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -3,10 +3,9 @@ on: [push]
 jobs:
   build:
     name: Run Accessibility Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-      - run: env
       - name: Checkout Source
         uses: actions/checkout@v2
 

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: env
       - name: Checkout Source
         uses: actions/checkout@v2
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,7 +34,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -8,6 +8,7 @@
       <h3 class="usa-alert__heading">{% if lang=="en" %}{{ post.notice_text }}{% elsif lang=="es" %}{{post.notice_text_es}}{% endif %}</h3>
       <p class="usa-alert__text">
         <a
+          class="pa11y-skip"
           href="{{ post.url | relative_url }}"
           >{% if lang=="en" %}{{ post.notice_link }}{% elsif lang=="es" %}{{post.notice_link}}{% endif %}</a
         >


### PR DESCRIPTION
Ok so there are a few changes in here.

1. Pa11y-ci stopped working on ubuntu-latest (22.04.1) so we're bumping the image version down to 20.04 as per this issue: [https://github.com/pa11y/pa11y-ci/issues/198](https://github.com/pa11y/pa11y-ci/issues/198)
2. We're getting a false alarm on the color contrast in the notice banner. Axe is claiming the anchor text is not high enough contrast. I can't replicate this error using Waves, IBM Equal Access Accessibility Checker, or Axe Devtools in the browser. Using Colour Contrast Analyzer, seems we're in the clear as well. See screenshots below:

No hover: 
<img width="478" alt="Screen Shot 2022-12-20 at 5 01 11 PM" src="https://user-images.githubusercontent.com/14644234/208775273-08e6e217-f74c-4761-8027-5183c1eeb4af.png">

Hover:
<img width="484" alt="Screen Shot 2022-12-20 at 5 00 54 PM" src="https://user-images.githubusercontent.com/14644234/208775294-34934746-d6d3-4000-b6f9-0c00ab91e833.png">

So I added the .pa11y-skip class to skip that element.

3. I upgraded the actions/checkout steps to use v3 because Github keeps yelling at us.

All seems well now.