### PR TITLE
Adding new alert component to 404 page and resources page

### DIFF
--- a/_assets/js/redirect404.js
+++ b/_assets/js/redirect404.js
@@ -28,8 +28,8 @@ function attemptToRedirect(attemptedPath, manual, generated) {
     }
   }
 
-    // If we make it here, it's a real 404.
-    showNotFound();
+  // If we make it here, it's a real 404.
+  showNotFound();
 }
 
 const gotRedirects = {};

--- a/_assets/js/redirect404.js
+++ b/_assets/js/redirect404.js
@@ -1,3 +1,7 @@
+function showNotFound() {
+  document.getElementById('redirect-pending').style.display = 'none';
+}
+
 function attemptToRedirect(attemptedPath, manual, generated) {
   if (!attemptedPath.replaceAll('/', '').trim()) {
     return; // Don't even try if the path is empty
@@ -23,6 +27,9 @@ function attemptToRedirect(attemptedPath, manual, generated) {
       return;
     }
   }
+
+    // If we make it here, it's a real 404.
+    showNotFound();
 }
 
 const gotRedirects = {};

--- a/_assets/js/redirect404.js
+++ b/_assets/js/redirect404.js
@@ -1,7 +1,3 @@
-function showNotFound() {
-  document.getElementById('redirect-pending').style.display = 'none';
-}
-
 function attemptToRedirect(attemptedPath, manual, generated) {
   if (!attemptedPath.replaceAll('/', '').trim()) {
     return; // Don't even try if the path is empty
@@ -27,9 +23,6 @@ function attemptToRedirect(attemptedPath, manual, generated) {
       return;
     }
   }
-
-  // If we make it here, it's a real 404.
-  showNotFound();
 }
 
 const gotRedirects = {};

--- a/_assets/js/redirect404.js
+++ b/_assets/js/redirect404.js
@@ -1,6 +1,5 @@
 function showNotFound() {
   document.getElementById('redirect-pending').style.display = 'none';
-  document.getElementById('redirect-failed').style.display = 'unset';
 }
 
 function attemptToRedirect(attemptedPath, manual, generated) {

--- a/_assets/sass/custom/_site_alert.scss
+++ b/_assets/sass/custom/_site_alert.scss
@@ -14,11 +14,6 @@
     background-color: #FBF3D1;
 }
 
-// Change the alert text color
-.usa-alert__text {
-    color: #005ea2 !important;
-}
-
 // Change the anchor link styling to primary color darker
 #warning-banner a:hover {
     color: #1a4480;

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -1,7 +1,7 @@
 {% assign lang = page.lang %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
-<div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" markdown="0">
+<div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" markdown="0" role="alert">
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
       <p class="usa-alert__text">{{ include.text }}</p>

--- a/_includes/common-alert.html
+++ b/_includes/common-alert.html
@@ -4,6 +4,6 @@
 <div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" id="{% if include.redirect == true %}redirect-pending{% endif %}" markdown="0" role="alert">
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
-      <p class="usa-alert__text">{{ include.text | markdownify }}</p>
+      <p class="usa-alert__text pa11y-skip">{{ include.text | markdownify }}</p>
     </div>
 </div>

--- a/_includes/common-alert.html
+++ b/_includes/common-alert.html
@@ -4,6 +4,6 @@
 <div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" id="{% if include.redirect == true %}redirect-pending{% endif %}" markdown="0" role="alert">
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
-      <p class="usa-alert__text pa11y-skip">{{ include.text | markdownify }}</p>
+      <p class="usa-alert__text">{{ include.text | markdownify }}</p>
     </div>
 </div>

--- a/_includes/common-alert.html
+++ b/_includes/common-alert.html
@@ -1,4 +1,3 @@
-<<<<<<< HEAD:_includes/common-alert.html
 {% assign lang = page.lang %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
@@ -6,11 +5,5 @@
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
       <p class="usa-alert__text">{{ include.text | markdownify }}</p>
-=======
-<div class="usa-alert usa-alert--warning margin-bottom-4">
-    <div class="usa-alert__body">
-      <h2 class="usa-alert__heading">{{ include.title }}</h2>
-      <p class="usa-alert__text">{{ include.text }}</p>
->>>>>>> main:_includes/alert.html
     </div>
 </div>

--- a/_includes/common-alert.html
+++ b/_includes/common-alert.html
@@ -4,6 +4,6 @@
 <div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" id="{% if include.redirect == true %}redirect-pending{% endif %}" markdown="0" role="alert">
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
-      <p class="usa-alert__text">{{ include.text }}</p>
+      <p class="usa-alert__text">{{ include.text | markdownify }}</p>
     </div>
 </div>

--- a/_includes/common-alert.html
+++ b/_includes/common-alert.html
@@ -1,7 +1,7 @@
 {% assign lang = page.lang %}
 {% if lang==nil %}{% assign lang="en" %}{% endif %}
 
-<div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" markdown="0" role="alert">
+<div class="usa-alert usa-alert--{{ include.type }} margin-bottom-4" id="{% if include.redirect == true %}redirect-pending{% endif %}" markdown="0" role="alert">
     <div class="usa-alert__body">
       {% if include.title != nil %}<h2 class="usa-alert__heading">{{ include.title }}</h2>{% endif %}
       <p class="usa-alert__text">{{ include.text }}</p>

--- a/_includes/ta-link-back.html
+++ b/_includes/ta-link-back.html
@@ -1,7 +1,0 @@
-<div
-  class="usa-summary-box related-content-container border-0 padding-2 bg-primary-lighter margin-bottom-2"
->
-  <div class="usa-summary-box__text">
-   <p>The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former [Technical Assistance Materials page](https://archive.ada.gov/ta-pubs-pg2.htm).</p>
-  </div>
-</div>

--- a/_layouts/full.html
+++ b/_layouts/full.html
@@ -6,7 +6,7 @@ layout: default
   <div class="grid-row">
     <div id="crt-page--content">
       {% if page.disclaimer %}
-      {% include alert.html type="warning" title="This is a test site. Do not rely on the information provided." text="This webpage is a prototype meant for user research. It has not undergone final review for legal accuracy and is not intended to provide legal guidance." %}
+      {% include common-alert.html type="warning" title="This is a test site. Do not rely on the information provided." text="This webpage is a prototype meant for user research. It has not undergone final review for legal accuracy and is not intended to provide legal guidance." %}
       {% endif %}
       <h1 id="top">{{page.title}}</h1>
       <div class="crt-landing--separator_small"></div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -35,9 +35,11 @@ layout: default
       id="crt-page--content"
       class="mobile-lg:grid-col {% if page.sidenav %}tablet:grid-col-12 desktop:grid-col-8{% endif %}"
     >
-      {% if page.title =='Page not found' %}
+    {% if page.title =='Page not found' %}
+      <div id="redirect-pending">
         {% include alert.html type="info" text="We're checking the archive.ADA.gov site for you, please wait." %}
-      {% endif %}
+      </div>
+    {% endif %}
       {% if page.disclaimer %}
         {% include alert.html type="warning" title="This is a test site. Do not rely on the
         information provided." text="This webpage is a prototype meant for user research. It has not

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -37,7 +37,7 @@ layout: default
     >
     {% if page.title =='Page not found' %}
       <div id="redirect-pending">
-        {% include alert.html type="info" text="We're checking the archive.ADA.gov site for you, please wait." %}
+        {% include alert.html type="info" text="We're searching the ADA sites, please wait." %}
       </div>
     {% endif %}
       {% if page.disclaimer %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -35,11 +35,9 @@ layout: default
       id="crt-page--content"
       class="mobile-lg:grid-col {% if page.sidenav %}tablet:grid-col-12 desktop:grid-col-8{% endif %}"
     >
-    {% if page.title =='Page not found' %}
-      <div id="redirect-pending">
-        {% include alert.html type="info" text="We're searching the ADA sites, please wait." %}
-      </div>
-    {% endif %}
+      {% if page.common-alert %}
+        {% include common-alert.html redirect=page.common-alert.redirect type=page.common-alert.type text=page.common-alert.text %}
+      {% endif %}
       {% if page.disclaimer %}
         {% include alert.html type="warning" title="This is a test site. Do not rely on the
         information provided." text="This webpage is a prototype meant for user research. It has not

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,7 +39,7 @@ layout: default
         {% include common-alert.html redirect=page.common-alert.redirect type=page.common-alert.type text=page.common-alert.text %}
       {% endif %}
       {% if page.disclaimer %}
-        {% include alert.html type="warning" title="This is a test site. Do not rely on the
+        {% include common-alert.html type="warning" title="This is a test site. Do not rely on the
         information provided." text="This webpage is a prototype meant for user research. It has not
         undergone final review for legal accuracy and is not intended to provide legal guidance." %}
       {% endif %}

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -3,6 +3,11 @@ permalink: /404.html
 title: Page not found
 sitemap: false
 sidenav: false
+common-alert:
+  redirect: true
+  type: info
+  text: |-
+    We're searching the ADA sites, please wait.
 ---
 
 We're sorry, the page you're looking for can't be found on the ADA.gov website.

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -10,7 +10,4 @@ We're sorry, the page you're looking for can't be found on the ADA.gov website.
 Please try the following:
 
 - Use the Search function to search for the words or phrases.
-
 - Check the <a target="blank" href="https://archive.ada.gov">archive.ADA.gov</a> site for more ADA materials.
-
-

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -7,7 +7,7 @@ common-alert:
   redirect: true
   type: info
   text: |-
-    We're searching the ADA sites, please wait.
+    Your page isn’t on the new [ADA.gov](https://www.ada.gov/). We are conducting a search of the archive ADA site in the background. Please wait...
 ---
 
 We're sorry, the page you're looking for can't be found on the ADA.gov website.

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -5,11 +5,6 @@ sitemap: false
 sidenav: false
 ---
 
-<div id="redirect-pending">
-We're checking <a target="blank" href="https://archive.ada.gov">Archive.ADA.gov</a> for you, please wait...
-</div>
-
-<div id="redirect-failed" style="display: none">
 We're sorry, the page you're looking for can't be found on the ADA.gov website.
 
 Please try the following:

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -11,7 +11,7 @@ redirect_from:
     - /ta_titleiii.html
 ---
 
-{% include alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former Technical Assistance Materials page." %}
+{% include common-alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former Technical Assistance Materials page." %}
 {% include ta-article-list.html %}
 
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -11,7 +11,7 @@ redirect_from:
     - /ta_titleiii.html
 ---
 
-{% include common-alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former Technical Assistance Materials page." %}
+{% include common-alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former [Technical Assistance Materials page](https://archive.ada.gov/ta-pubs-pg2.htm)." %}
 {% include ta-article-list.html %}
 
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -11,7 +11,7 @@ redirect_from:
     - /ta_titleiii.html
 ---
 
-{% include common-alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former [Technical Assistance Materials page](https://archive.ada.gov/ta-pubs-pg2.htm)." %}
+{% include common-alert.html type="info" text="The complete inventory of our ADA Resources is coming soon to this page. In the meantime, you can access them on our former [Technical Assistance Materials page](https://archive.ada.gov/ta-pubs-pg2.htm){:.pa11y-skip}." %}
 {% include ta-article-list.html %}
 
 


### PR DESCRIPTION
Started as an offshoot of #450 
🌎 There is a summary box on the resources page and no alert on the 404 page.
⛔ The summary box does not effectively highlight the information.
✅ This PR adds an alert component and includes it on the resources and 404 page to better highlight text.

**Before**

**Resource page**
![image](https://user-images.githubusercontent.com/18104884/211348547-40521d18-9280-482b-8435-b6ed5a2c4afe.png)

**404 page**
![image](https://user-images.githubusercontent.com/18104884/211348779-5f264625-edb6-4e6f-acb3-894ee42dc2ed.png)

**After**

**Resource page**
![image](https://user-images.githubusercontent.com/18104884/212946082-7921556c-c633-4f4c-9e63-f050ce7dde8b.png)


**404 page**
![image](https://user-images.githubusercontent.com/18104884/214915194-5ec2f8cd-b916-49a0-85d7-8d378e9c82cb.png)



https://user-images.githubusercontent.com/18104884/212182738-8b4022c0-593b-430e-8274-9ff97ddd1c85.mov

**Test plan**
Navigate to the resources page and verify that the alert component looks as expected on desktop and mobile.
Navigate to a known redirect (i.e. /ada_title_I/) and verify that when you see the 404 page before being redirected the new alert is visible.
Navigate to a known 404 (i.e. /xyz/) and verify that the alert is not visible.