### PR TITLE
Leave room for action buttons on the sidenav

### DIFF
--- a/_assets/sass/custom/_sidenav.scss
+++ b/_assets/sass/custom/_sidenav.scss
@@ -7,6 +7,12 @@
 }
 
 #crt-page--sidenav {
+  @include at-media(desktop) {
+    max-height: calc(100vh - 3rem);
+    display: flex;
+    flex-direction: column;
+  }
+
   a:not(.crt-page--downloadpdf-button)  {
     color: color($theme-text-color);
 

--- a/_pages/law-and-regs/title-iii-regulations.md
+++ b/_pages/law-and-regs/title-iii-regulations.md
@@ -2,6 +2,7 @@
 title: Americans with Disabilities Act Title III Regulations
 permalink: /law-and-regs/title-iii-regulations/
 publish-date: 2012-03-08 00:00:00
+print: true
 back-to-top: true
 subnavigation: true
 redirect_from:


### PR DESCRIPTION
- 🌎 Pages have "download" and "print" buttons for users who don't want to view the pages online.
- ⛔ On pages where the TOC takes up the full height, users have to scroll to the bottom of large documents to see the buttons.
- ✅ This PR fixes that by having the sidenav give room when in desktop mode. Mobile mode is unaffected.
- 🔮 Future PRs will add links to download their PDF equivalents

Before:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/15126660/211393582-3a944343-a9e6-40fc-9856-5ca96c1190c2.png">

After:

<img width="512" alt="image" src="https://user-images.githubusercontent.com/15126660/211393620-89df91e9-7e9a-48ff-9eca-e72910a9ddc2.png">

