### PR TITLE
Limit page width to improve readability.

### DIFF
--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -9,6 +9,13 @@
   padding-right: 2rem;
   width: 100%;
 
+  @include at-media(desktop) {
+    &.compact {
+      max-width: 64rem;
+      margin-left: 0px;
+    }
+  }
+
   #crt-page--content {
     .crt-lead {
       > p,

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="crt-page grid-container">
+<div class="crt-page grid-container {% if page.compact %}compact{% endif %}">
   {% include breadcrumbs.html %}
   <div class="grid-row grid-gap-xl">
     {% if page.sidenav %}

--- a/_pages/cases.md
+++ b/_pages/cases.md
@@ -14,6 +14,7 @@ redirect_from:
   - /enforce.htm
   - /enforce_activities/
 sidenav: false
+compact: true
 lead: |-
   The Department of Justice enforces the ADA through lawsuits and settlement agreements to achieve greater access, inclusion, and equal opportunity for people with disabilities.
 ---

--- a/_pages/law-and-regs/design-standards/index.md
+++ b/_pages/law-and-regs/design-standards/index.md
@@ -5,6 +5,7 @@ lead: |-
   The ADA Standards for Accessible Design—along with the [Title II](../title-ii-2010-regulations/) and [Title III](../title-iii-regulations/) regulations—say what is required for a building or facility to be physically accessible to people with disabilities.
 lang: "en"
 sidenav: false
+compact: true
 redirect_from:
   - 2010adastandards_index.htm
 ---

--- a/_pages/law-and-regs/index.md
+++ b/_pages/law-and-regs/index.md
@@ -2,6 +2,7 @@
 permalink: /law-and-regs/
 title: Review Laws, Regulations & Standards
 sidenav: false
+compact: true
 redirect_from:
     - /2010_regs.htm
     - /pubs/ada.htm

--- a/_pages/notices/_posts/2022-11-16-ada-launch.md
+++ b/_pages/notices/_posts/2022-11-16-ada-launch.md
@@ -5,6 +5,7 @@ notice_text: The new ADA.gov has launched!
 notice_text_es:  The new ADA.gov has launched!
 notice_link: Learn more about the new site here.
 sidenav: false
+compact: true
 publish-date: 2022-11-18 00:00:00
 news-item: true
 ---

--- a/_pages/search.md
+++ b/_pages/search.md
@@ -3,6 +3,7 @@ permalink: /search/
 title: Search
 sitemap: false
 sidenav: false
+compact: true
 redirect_from:
   - /search.htm
 ---


### PR DESCRIPTION
- 🌎 As pointed out by Tina, some pages on ada.gov feel difficult to read.
- ⛔ Her theory is that this is because the text width is too large
- ✅ This commit explores shrinking that width to 64rem (the "small screen" max width used throughout the site)
- 🔮 This is a draft to evaluate whether this would make pages more readable - feedback is encouraged!

Before: scanning the line:

> Knowing when the 1991 or the 2010 ADA Standards apply to buildings and facilities is important in determining if your building or facility complies with the ADA. The [ADA Requirements: Effective Date and Compliance Date guide](https://archive.ada.gov/revised_effective_dates-2010.htm) helps to explain which version of the ADA Standards to use and when.

is difficult because the eye has to travel far on large screens.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/15126660/211418901-b9b5026c-659f-411b-ac1e-bbee03c5dbbf.png">


After feels easier on the eyes:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/15126660/211419081-3e93a48a-1a78-4f18-a91f-fb4ae2016db0.png">
