### PR TITLE
Allow manually triggering workflows.

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,5 +1,7 @@
 name: Run Accessibility Tests
-on: [push]
+on:
+  push:
+  workflow_call:
 jobs:
   build:
     name: Run Accessibility Tests

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,9 @@ name: Lint Code Base
 #############################
 # Start the job on all push #
 #############################
-on: [push]
+on:
+  push:
+  workflow_call:
 
 ###############
 # Set the Job #

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,12 @@
+# Manually triggers other actions.
+name: Manually trigger workflows
+on:
+  workflow_dispatch:
+
+jobs:
+  ally:
+    uses: usdoj-crt/beta-ada/.github/workflows/ally.yml@main
+  linter:
+    uses: usdoj-crt/beta-ada/.github/workflows/linter.yml@main
+  preview:
+    uses: usdoj-crt/beta-ada/.github/workflows/preview.yml@main

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     types: [opened]
+  workflow_call:
 
 jobs:
   comment:


### PR DESCRIPTION
- 🌎 These files run when a branch is pushed to the repository.
- ⛔ In some cases, they won't run - like if the user doesn't have access to the repo
- ✅ This commit lets folks with access trigger CI/CD against branches. It will also let us rerun failed actions (in the even of timeout, etc) without requiring a duplicate branch push.

See: https://github.blog/2022-02-10-using-reusable-workflows-github-actions/

FYI - would require sharing actions with other projects in usdoc-crt to make available:

<img width="713" alt="image" src="https://user-images.githubusercontent.com/15126660/211888972-7099ba58-eed5-4106-873b-c58825afe092.png">
