### PR TITLE
Fix compact alignment on large screens

### DIFF
--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -22,8 +22,7 @@
       margin-right: auto;
       max-width: 64rem;
 
-      position: relative;
-      right: calc((95rem - 64rem) / 2);
+
     }
   }
 

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -20,7 +20,10 @@
     &.compact {
       margin-left: auto;
       margin-right: auto;
-      max-width: 95rem;
+      max-width: 64rem;
+
+      position: relative;
+      right: calc((95rem - 64rem) / 2);
     }
   }
 

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -22,7 +22,8 @@
       margin-right: auto;
       max-width: 64rem;
 
-
+      position: relative;
+      right: calc((95rem - 64rem) / 2);
     }
   }
 

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -24,6 +24,7 @@
 
       position: relative;
       right: calc((95rem - 64rem) / 2);
+      background-color: white;
     }
   }
 

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -16,6 +16,14 @@
     }
   }
 
+  @include at-media(min-width: 64rem) {
+    &.compact {
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 95rem;
+    }
+  }
+
   #crt-page--content {
     .crt-lead {
       > p,

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -16,7 +16,7 @@
     }
   }
 
-  @include at-media(min-width: 64rem) {
+  @media(min-width: 64rem) {
     &.compact {
       margin-left: auto;
       margin-right: auto;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9491,7 +9491,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
This fixes an issue on very large screens, where the alignment for the new compact pages was off (see GIFs below).

- 🌎 Compact pages don't stretch to fill the screen
- ⛔ On large screens, this means they are limited to the left 64rem of the screen
- ✅ This commit auto-aligns them in the center, in the same was as the toolbar.

Before:

(The misalignment is only on the large resolution - other resolutions are unaffected)

![before](https://user-images.githubusercontent.com/15126660/214585848-7cc6fe50-0310-457b-93f2-8ad349411280.gif)

After:

(All resolutions look good now!)

![sizes](https://user-images.githubusercontent.com/15126660/214585872-667e7bea-f8f6-4697-83dd-f25a05804197.gif)
