### PR TITLE
Fix page offset at narrow resolutions

### DIFF
--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -16,14 +16,19 @@
     }
   }
 
-  @media(min-width: 64rem) {
+  @media(min-width: 95rem) {
     &.compact {
       margin-left: auto;
       margin-right: auto;
-      max-width: 64rem;
+      max-width: 95rem;
+      padding-right: calc(95rem - 64rem);
+      background-color: white;
+    }
+  }
 
-      position: relative;
-      right: calc((95rem - 64rem) / 2);
+  @media(min-width: 64rem) and (max-width: 95rem) {
+    &.compact {
+      max-width: 64rem;
       background-color: white;
     }
   }


### PR DESCRIPTION
This is a quick followup to the previous PR (https://github.com/usdoj-crt/beta-ada/pull/479) which missed an issue that affected the compact view at narrow resolutions:

- 🌎 We try to align compact pages with the title bar
- ⛔ Right now this is causing the page to move off of the screen on specific (narrow, desktop) resolutions, as we're using position: relative with a definite right margin with certain widths.
- ✅ This commit changes the approach to force the page to the same width as the title bar at all times (95rem) but with padding to align it properly

Before:

![before-margin](https://user-images.githubusercontent.com/15126660/215822295-36ae0551-0d17-4bcc-8d4a-dc975a19483b.gif)

After:

![after-margin](https://user-images.githubusercontent.com/15126660/215822310-6db3483e-d2e4-446c-97e2-d3a102c34b96.gif)