### PR TITLE
Rearrange content types on the homepage.

### DIFF
--- a/_assets/sass/custom/_utilities.scss
+++ b/_assets/sass/custom/_utilities.scss
@@ -20,3 +20,7 @@
   @include grid-gap(6);
 }
 
+.no-bullets {
+  list-style-type: none;
+  padding-left: 0px;
+}

--- a/_includes/landing/service-animals.html
+++ b/_includes/landing/service-animals.html
@@ -26,13 +26,7 @@
                   <h3 class="margin-bottom-0">
                     {{ section.heading }}
                   </h3>
-                  <p class="margin-y-0">
-                    {{ section.content }}
-                  </p>
-                  <p>
-                    Examples:
-                  </p>
-                  <ul class="padding-left-2">
+                  <ul style="margin-top: 0px" class="no-bullets padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
                         <a href="{{example.link | relative_url }}">

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -63,35 +63,21 @@ learn:
   sections:
     - heading: Featured Topics
       content: |-
-        Quickly learn about topics covered by the ADA.
+        These overviews are a basic starting point for understanding areas the ADA covers.
       icon: landing/featured_topics_gold.svg
       examples:
         - ex1:
-          title: 'Featured Topic: Service Animals'
+          title: 'Service Animals'
           link: topics/service-animals
         - ex2:
-          title: 'Featured Topic: Parking'
+          title: 'Parking'
           link: topics/parking
         - ex3:
-          title: 'Featured Topic: Mobility Devices'
+          title: 'Mobility Devices'
           link: topics/mobility-devices
-    - heading: Laws & Regulations
-      content: |-
-        Find legal documents that are enforceable under the ADA.
-      icon: landing/laws_regs_standards_gold.png
-      examples:
-      - ex1:
-        title: State and Local Government Services (Title II)
-        link: law-and-regs/title-ii-2010-regulations/
-      - ex2:
-        title: Public Accommodations (Title III)
-        link: law-and-regs/title-iii-regulations/
-      - ex3:
-        title: ADA Standards for Accessible Design
-        link: law-and-regs/design-standards/
     - heading: Resources
       content: |-
-        Get more details about topics covered by the ADA.
+        Get more detailed guidance on some ADA topics.
       icon: landing/guidance_resource_materials_gold.png
       examples:
         - ex1:
@@ -103,22 +89,10 @@ learn:
         - ex3:
           title: Frequently Asked Questions about Service Animals
           link: resources/service-animals-faqs
-
-service-animals:
-  heading: Service Animals and the ADA
-  lead: |-
-    Understand how the ADA defines a service animal and what your rights are under the law.
-  sections:
-    - heading: Featured Topics
-      content: Quickly learn about topics covered by the ADA.
-      icon: landing/featured_topics_grey_bg.png
-      examples:
-      - ex1:
-        title: 'Featured Topic: Service Animals'
-        link: topics/service-animals
     - heading: Laws & Regulations
-      content: Find legal documents that are enforceable under the ADA.
-      icon: landing/laws_regs_standards_grey_bg.png
+      content: |-
+        Find legal documents that are enforceable under the ADA in a court of law.
+      icon: landing/laws_regs_standards_gold.png
       examples:
       - ex1:
         title: State and Local Government Services (Title II)
@@ -126,8 +100,22 @@ service-animals:
       - ex2:
         title: Public Accommodations (Title III)
         link: law-and-regs/title-iii-regulations/
+      - ex3:
+        title: ADA Standards for Accessible Design
+        link: law-and-regs/design-standards/
+
+service-animals:
+  heading: Service Animals and the ADA
+  lead: |-
+    Understand how the ADA defines a service animal and what your rights are under the law.
+  sections:
+    - heading: Featured Topics
+      icon: landing/featured_topics_grey_bg.png
+      examples:
+      - ex1:
+        title: 'Featured Topic: Service Animals'
+        link: topics/service-animals
     - heading: Resources
-      content: Get more details about topics covered by the ADA.
       icon: landing/guidance_resource_materials_grey_bg.png
       examples:
         - ex1:
@@ -136,6 +124,15 @@ service-animals:
         - ex2:
           title: 'ADA Requirements: Service Animals'
           link: resources/service-animals-2010-requirements
+    - heading: Laws & Regulations
+      icon: landing/laws_regs_standards_grey_bg.png
+      examples:
+      - ex1:
+        title: State and Local Government Services (Title II)
+        link: law-and-regs/title-ii-2010-regulations/
+      - ex2:
+        title: Public Accommodations (Title III)
+        link: law-and-regs/title-iii-regulations/
 
 
 report:

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -113,7 +113,7 @@ service-animals:
       icon: landing/featured_topics_grey_bg.png
       examples:
       - ex1:
-        title: 'Featured Topic: Service Animals'
+        title: 'Service Animals'
         link: topics/service-animals
     - heading: Resources
       icon: landing/guidance_resource_materials_grey_bg.png


### PR DESCRIPTION
Rearrange content types on the homepage to match https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/641#issuecomment-1428630799

- 🌎 The site offers, in increasing levels of technical language, Featured
  Topics, Resources, and Laws & Regulations.
- ⛔ These are out of order on the homepage as is - that is, resources
  are the "step up" from topics, and laws & regs from that.
- ✅ This PR reorganizes them and updates some wording.

<img width="1457" alt="image" src="https://user-images.githubusercontent.com/15126660/219472961-da46338c-66f9-4df8-8b5e-39b2eccfdfe5.png">

Full demo across desktop/mobile/large screen:

![homepage](https://user-images.githubusercontent.com/15126660/219473662-50e6ca63-3893-4a2b-9f00-f3514dc3b000.gif)
