### PR TITLE
Address Netlify errors

### DIFF
--- a/_assets/js/netlify/generateChildElements.js
+++ b/_assets/js/netlify/generateChildElements.js
@@ -1,3 +1,5 @@
+import toStyle from 'css-to-style';
+
 const generateChildElements = (html) =>
   html.map((item) => {
     if (item.nodeType === Node.TEXT_NODE) return item.wholeText;
@@ -5,11 +7,19 @@ const generateChildElements = (html) =>
     // to make sure.
     if (item.nodeType !== Node.ELEMENT_NODE) return;
     const itemHasChildren = item.childNodes?.length > 0;
-    const content = [];
+    let content = [];
     if (itemHasChildren) {
       content.push(generateChildElements([...Array.from(item.childNodes)]));
+    } else {
+      content = null;
     }
-    const attrs = Object.fromEntries([...item.attributes].map((attr) => [attr.name, attr.value]));
+    const attrs = Object.fromEntries([...item.attributes].map((attr) => {
+      let val = attr.value;
+      if (attr.name === 'style') {
+        val = toStyle(attr.value);
+      }
+     return [attr.name, val]
+    }));
     return h(item.nodeName.toLowerCase(), attrs, content);
   });
 

--- a/_assets/js/netlify/makeHTMLFromBodyContent.js
+++ b/_assets/js/netlify/makeHTMLFromBodyContent.js
@@ -3,9 +3,11 @@ md.options['html'] = true;
 md.options['linkify'] = true;
 const parser = new DOMParser();
 function makeHTMLFromBodyContent(bodyContent) {
+  // Replace any <hr> tags with markdown so they render outside of the nearest <p> tag
+  const content = bodyContent.replace(/<hr>/g, "***");
   // The DOMParser returns a full HTML document, so grabbing the first child element actually grabs the <html> element because it is the first element under <!doctype>
   // the second child element of the <html> is the <body> element. We aren't starting at the <html> element but rather the <!doctype> tag.
-  const html = parser.parseFromString(md.render(bodyContent), 'text/html');
+  const html = parser.parseFromString(md.render(content), 'text/html');
   const elementsArray = Array.from(html.children[0].children[1].childNodes);
   return elementsArray;
 };

--- a/admin/index.html
+++ b/admin/index.html
@@ -27,9 +27,6 @@ layout: null
         margin-left: 75px;
         width: 150px;
       }
-      p {
-        color: red;
-      }
       button {
         margin-top: 0px !important;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "anchor-js": "^4.3.1",
         "babel-loader": "^8.2.3",
         "core-js": "^3.21.1",
+        "css-to-style": "^1.4.0",
         "gumshoejs": "^5.1.2",
         "markdown-it": "^13.0.1",
         "pa11y-ci": "^3.0.1",
@@ -2938,6 +2939,11 @@
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
       }
+    },
+    "node_modules/css-to-style": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/css-to-style/-/css-to-style-1.4.0.tgz",
+      "integrity": "sha512-FxLJRS+zzAjICI/AwpXUQR+aXrDOksrMTPpoKVwcGP0ARCxY5K3eRfgPW+pJrFXG46SKuxWOufJheis8Bhc2kg=="
     },
     "node_modules/css-what": {
       "version": "5.0.1",
@@ -8382,6 +8388,11 @@
         "nth-check": "^2.0.0"
       }
     },
+    "css-to-style": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/css-to-style/-/css-to-style-1.4.0.tgz",
+      "integrity": "sha512-FxLJRS+zzAjICI/AwpXUQR+aXrDOksrMTPpoKVwcGP0ARCxY5K3eRfgPW+pJrFXG46SKuxWOufJheis8Bhc2kg=="
+    },
     "css-what": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
@@ -9491,7 +9502,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "anchor-js": "^4.3.1",
     "babel-loader": "^8.2.3",
     "core-js": "^3.21.1",
+    "css-to-style": "^1.4.0",
     "gumshoejs": "^5.1.2",
     "markdown-it": "^13.0.1",
     "pa11y-ci": "^3.0.1",


### PR DESCRIPTION
This diff addresses style and html react rendering errors in Netlify so they do not break the page.

1.  Navigate to "/admin/"
2.  Click on a previously broken article in a collection (i.e. the Guide to Disability Rights in the Resources collection)
3.  Verify that the html tag error is handled and preview appears unbroken
4.  Click on a previously broken article in a collection (i.e. Restriping Parking Spaces in the Resources collection)
5. Verify that the style prop error is handled and preview appears unbroken

**Before**
![image](https://user-images.githubusercontent.com/18104884/222497313-d6ffa451-6cfa-4a1e-8f06-46020de657ec.png)

**After**
![image](https://user-images.githubusercontent.com/18104884/222497661-49d5a68b-7d1f-474a-82e7-c6eb19f011c6.png)
