### PR TITLE
Fix broken service animals link

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -123,7 +123,7 @@ service-animals:
           link: resources/service-animals-faqs
         - ex2:
           title: 'ADA Requirements: Service Animals'
-          link: resources/service-animals-2010-requirements
+          link: resources/service-animals-2010-requirements/
     - heading: Laws & Regulations
       icon: landing/laws_regs_standards_grey_bg.png
       examples:


### PR DESCRIPTION
Credit to @nguyen-tina for the catch!

This homepage link is broken:

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/15126660/223850995-2ff22862-15d6-4c76-8863-f6f5def6b53f.png">

This PR fixes it!