### PR TITLE
Add a script to find dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ playwright-report/
 test-results/
 _assets/js/dist/*
 _assets/css
+/scripts/out

--- a/_config.yml
+++ b/_config.yml
@@ -184,6 +184,7 @@ exclude:
   - /playwright-report
   - /mock_data
   - make_redirects.rb
+  - /scripts
 
 assets:
   autoprefixer:

--- a/scripts/print_dates.sh
+++ b/scripts/print_dates.sh
@@ -6,6 +6,14 @@ echo ""
 
 echo "Date|File" > "$outfile"
 for file in $(git ls-files '*.md'); do
+  if [[ ! "$file" =~ ^_pages ]]; then
+    continue
+  fi
+
+  if [[ "$file" =~ ^_pages/redirects ]]; then
+    continue
+  fi
+
   date="$(git log -1 --no-decorate --pretty=format:%cs "$file" 2>&1)"
   echo "$date|$file" | tee -a "$outfile"
 done

--- a/scripts/print_dates.sh
+++ b/scripts/print_dates.sh
@@ -1,0 +1,14 @@
+outfile="$(git rev-parse --show-toplevel)/scripts/out/dates.csv"
+
+mkdir -p out
+echo "⌛ This might take a minute, please wait..."
+echo ""
+
+echo "Date|File" > "$outfile"
+for file in $(git ls-files '*.md'); do
+  date="$(git log -1 --no-decorate --pretty=format:%cs "$file" 2>&1)"
+  echo "$date|$file" | tee -a "$outfile"
+done
+
+echo ""
+echo "🎉 Dates written to $outfile"


### PR DESCRIPTION
As discussed with @c2nelson during pairing, this will make finding the commit date for files easier.

# What does this change?

- 🌎 Search engine recency requires accurate commit dates.
- ⛔ Right now, other results are prioritized over our dates because we don't have up-to-date numbers to give them.
- ✅ This commit adds a script to gather commit dates.
- 🔮 Future commits can expand on this to gather other automated info that we need for site content management.

# How to test:

- [ ] Run ./scripts/print_dates.sh
- [ ] View the output at ./scripts/out/dates.csv

# Proof it works:

[dates.csv](https://github.com/usdoj-crt/beta-ada/files/11140428/dates.csv)

Example output: 

![dates](https://user-images.githubusercontent.com/15126660/229570610-612d94f6-7787-494f-a023-be3fa51545c1.gif)
