### PR TITLE
Filter title ii and title iii tags from related content

### DIFF
--- a/_includes/related-content.html
+++ b/_includes/related-content.html
@@ -6,6 +6,7 @@
 <!-- The array containing the tags needs to be initialized with some content, not sure why -->
 {% assign tagArray = 'a,b' | split:"," %}
 {% for tag in page.tags %}
+{% if tag != "title ii" and tag != "title iii" %}
 {% for post in pagesAndPosts %}
 {% if site.data.tags.allowed-tags contains tag %}
 {% if post.tags contains tag %}
@@ -15,6 +16,7 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endfor %}
 {% assign tagArray = tagArray | uniq %}
 {% assign tagSize = tagArray | size %}


### PR DESCRIPTION
This PR filters the title ii and title iii tags from the related content boxes to make them more relevant to the page.

**Before**

![image](https://user-images.githubusercontent.com/18104884/229582064-428b8c18-bf0a-48cd-b82b-15fac7bdf065.png)

**After**

![image](https://user-images.githubusercontent.com/18104884/229581969-137a0c84-4ed3-4971-b07c-aeb45d1cbb15.png)

**Test Plan**
Spot check the pages on the site to verify that the related content box is functioning as expected.
