### PR TITLE
[Netlify] Render Includes components without variables

### DIFF
--- a/_assets/js/netlify/generatePageData.js
+++ b/_assets/js/netlify/generatePageData.js
@@ -9,7 +9,8 @@ export default function generatePageData(entry) {
   const print = entry.getIn(['data', 'print']);
   const sideNavPDF = entry.getIn(['data', 'sidenav-pdf']);
   const relatedContent = entry.getIn(['data', 'related-content']);
-  const bodyContentsArr = makeHTMLFromBodyContent(rawBodyContent);
+  const variables = entry.get('data').toJS();
+  const bodyContentsArr = makeHTMLFromBodyContent(rawBodyContent, variables);
   const pageData = {
     title,
     leadText,

--- a/_assets/js/netlify/makeHTMLFromBodyContent.js
+++ b/_assets/js/netlify/makeHTMLFromBodyContent.js
@@ -3,13 +3,13 @@ const md = window.markdownit();
 md.options['html'] = true;
 md.options['linkify'] = true;
 const parser = new DOMParser();
-function makeHTMLFromBodyContent(bodyContent) {
+function makeHTMLFromBodyContent(bodyContent, variables) {
   // Replace any <hr> tags with markdown so they render outside of the nearest <p> tag
   const content = bodyContent.replace(/<hr>/g, "***");
   // The DOMParser returns a full HTML document, so grabbing the first child element actually grabs the <html> element because it is the first element under <!doctype>
   // the second child element of the <html> is the <body> element. We aren't starting at the <html> element but rather the <!doctype> tag.
   const interimHTML = md.render(bodyContent);
-  const renderedHTML = renderWidgets(interimHTML);
+  const renderedHTML = renderWidgets(interimHTML, variables);
   const html = parser.parseFromString(renderedHTML, 'text/html');
   const elementsArray = Array.from(html.children[0].children[1].childNodes);
   return elementsArray;

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -8,5 +8,14 @@ const preview = createClass({
   },
   });
 
-const pages = ['index', 'topics', 'resources', 'law-and-regs', 'pages'];
+const pages = [
+  'index',
+  'topics',
+  'resources',
+  'law-and-regs',
+  'pages',
+  'design-standards',
+  'notices-posts',
+  'es',
+];
 pages.forEach((page) => CMS.registerPreviewTemplate(page, preview));

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -8,5 +8,5 @@ const preview = createClass({
   },
   });
 
-const pages = ['topics', 'resources', 'law-and-regs', 'pages'];
+const pages = ['index', 'topics', 'resources', 'law-and-regs', 'pages'];
 pages.forEach((page) => CMS.registerPreviewTemplate(page, preview));

--- a/_assets/js/netlify/renderMdWidgets.js
+++ b/_assets/js/netlify/renderMdWidgets.js
@@ -14,12 +14,12 @@ const tagNames = [
   'list_item',
 ];
 
-function buildEngine(variables) {
+function buildEngine(globals) {
   const engine = new Liquid({
     jekyllInclude: true,
     partials: '/_includes',
     ownPropertyOnly: false,
-    globals: {'page': variables},
+    globals,
   });
 
   tagNames.forEach((tagName) => {
@@ -150,7 +150,10 @@ function buildEngine(variables) {
 }
 
 function renderWidgets(interimHTML, variables) {
-  const engine = buildEngine(variables);
+  const engine = buildEngine({
+    'page': variables,
+    'site': window.jekyllSite,  // This is defined globally via site_json.rb
+  });
   const renderedHTML = engine.parseAndRenderSync(interimHTML);
   return renderedHTML;
 }

--- a/_assets/js/netlify/renderMdWidgets.js
+++ b/_assets/js/netlify/renderMdWidgets.js
@@ -1,56 +1,69 @@
 import { Liquid } from 'liquidjs';
 
 const tagNames = [
-    'accordion',
-    'asset',
-    'collapsible',
-    'details',
-    'figcaption',
-    'figure',
-    'fn',
-    'fnbody',
-    'footnotes',
-    'list',
-    'list_item'
+  'accordion',
+  'asset',
+  'collapsible',
+  'details',
+  'figcaption',
+  'figure',
+  'fn',
+  'fnbody',
+  'footnotes',
+  'list',
+  'list_item',
 ];
-const engine = new Liquid();
-tagNames.forEach(tagName => {
-engine.registerTag(tagName, {
-    parse(tagToken, remainTokens) {
-      this.value = tagToken.args;
-      if (tagName !== 'fn' && tagName !== 'asset') {
-      this.tpls = [];
-      this.liquid.parser
-        .parseStream(remainTokens)
-        .on('template', (tpl) => this.tpls.push(tpl))
-        // note that we cannot use arrow function because we need `this`
-        .on('tag:end'.concat(tagName), function () {
-          this.stop();
-        })
-        .on('end', () => {
-          throw new Error(`tag ${tagToken.getText()} not closed`);
-        })
-        .start();
-    }},
-    *render(context, emitter) {
+
+function buildEngine(variables) {
+  const engine = new Liquid({
+    jekyllInclude: true,
+    partials: '/_includes',
+    ownPropertyOnly: false,
+    globals: {'page': variables},
+  });
+
+  tagNames.forEach((tagName) => {
+    engine.registerTag(tagName, {
+      parse(tagToken, remainTokens) {
+        this.value = tagToken.args;
+        if (tagName !== 'fn' && tagName !== 'asset') {
+          this.tpls = [];
+          this.liquid.parser
+            .parseStream(remainTokens)
+            .on('template', (tpl) => this.tpls.push(tpl))
+            // note that we cannot use arrow function because we need `this`
+            .on('tag:end'.concat(tagName), function () {
+              this.stop();
+            })
+            .on('end', () => {
+              throw new Error(`tag ${tagToken.getText()} not closed`);
+            })
+            .start();
+        }
+      },
+      *render(context, emitter) {
         switch (tagName) {
-         case 'accordion':
+          case 'accordion':
             const options = this.value.split(' ');
             const accId = `accordion-${options[0].trim()}`;
             const multiselect = options.includes('multiselect');
             const expandable = options.includes('expandable');
             context._accordionID = accId;
             context._collapsedIDX = 1;
-            emitter.write(`<div class="usa-accordion netlify-preview ${expandable ? 'expand' : null}" ${multiselect ? 'aria-multiselectable="true"': null}>`);
+            emitter.write(
+              `<div class="usa-accordion netlify-preview ${expandable ? 'expand' : null}" ${
+                multiselect ? 'aria-multiselectable="true"' : null
+              }>`
+            );
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</div>');
             break;
-         case 'asset':
+          case 'asset':
             const valArr = this.value.split(' ');
             const imagePathArr = valArr[0].split('/');
             const imageTitle = imagePathArr[imagePathArr.length - 1];
             return `<img src="${window.location.origin}/assets/images/${imageTitle}">`;
-         case 'collapsible':
+          case 'collapsible':
             const accordionID = context._accordionID;
             let idx = context._collapsedIDX;
             const collapsedID = `${accordionID}-${idx}`;
@@ -58,17 +71,17 @@ engine.registerTag(tagName, {
             const content = this.tpls[0].str.split('</h2>');
             const heading = content[0].split('<h2>')[1].replace('<h2>', '').replace('</h2>', '');
             emitter.write(`<h2 class="usa-accordion__heading"">
-              <button class="usa-accordion__button pa11y-skip"
-                aria-expanded="true"
-                aria-controls="${collapsedID}">
-                ${heading}
-              </button>
-            </h2>
-            <div id="${collapsedID}" class="usa-accordion__content usa-prose">`);
+                 <button class="usa-accordion__button pa11y-skip"
+                   aria-expanded="true"
+                   aria-controls="${collapsedID}">
+                   ${heading}
+                 </button>
+               </h2>
+               <div id="${collapsedID}" class="usa-accordion__content usa-prose">`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</div>');
             break;
-         case 'details':
+          case 'details':
             const detailTitle = yield this.value;
             emitter.write(
               `<details data-detail-open='false'><summary><div><span class='pa11y-skip'>${detailTitle}</span></div></summary><div><p>`
@@ -76,65 +89,70 @@ engine.registerTag(tagName, {
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</p></div></details>');
             break;
-         case 'figcaption':
+          case 'figcaption':
             emitter.write(`<figcaption>`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</figcaption>');
             break;
-         case 'figure':
+          case 'figure':
             const figTitle = this.value;
             const figId = title.toLowerCase().trim().replaceAll(/\s/g, '');
             emitter.write(`<figure id=${figId}>
-              <strong>${figTitle}</strong><br/>`);
+                 <strong>${figTitle}</strong><br/>`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</figure>');
             break;
-         case 'fn':
+          case 'fn':
             const fnId = this.value;
             return `<sup><a href="#fn:${fnId}" class="footnote" id="fn-back:${fnId}">${fnId}</a></sup>`;
-         case 'fnbody':
+          case 'fnbody':
             const fnBodyId = this.value.trim();
             emitter.write(`<li id='fn:${fnBodyId}' class='footnotebody' value='${fnBodyId}'>`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write(`<a href='#fn-back:${fnBodyId}' class='backlink'>Back to text</a>`);
             break;
-         case 'footnotes':
+          case 'footnotes':
             emitter.write(`<div class='footnotes'><ol class='footnotelist'>`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</ol></div>');
             break;
-         case 'list':
+          case 'list':
             const listIconType = this.value;
             context._iconType = listIconType;
-            emitter.write("<ul class='usa-icon-list margin-bottom-2'>")
-            yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter)
-            emitter.write("</ul>");
+            emitter.write("<ul class='usa-icon-list margin-bottom-2'>");
+            yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
+            emitter.write('</ul>');
             break;
-         case 'list_item':
+          case 'list_item':
             const listItemIconType = context._iconType;
             emitter.write(
               `<li class='usa-icon-list__item'>
-                <div class='usa-icon-list__icon'>
-                  <div class='usa-icon' aria-hidden='true' 
-                      style="background-image:url('${window.location.origin}/assets/img/usa-icons/${listItemIconType}.svg')"
-                      >
-                  </div>
-                </div>
-                <div class='usa-icon-list__content'>
-              `);
+                   <div class='usa-icon-list__icon'>
+                     <div class='usa-icon' aria-hidden='true'
+                         style="background-image:url('${window.location.origin}/assets/img/usa-icons/${listItemIconType}.svg')"
+                         >
+                     </div>
+                   </div>
+                   <div class='usa-icon-list__content'>
+                 `
+            );
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write('</div></li>');
             break;
-         default:
+          default:
             break;
         }
-    }
-    })
-});
+      },
+    });
+  });
 
-function renderWidgets(interimHTML){
-   const renderedHTML = engine.parseAndRenderSync(interimHTML);
-   return renderedHTML;
+  return engine;
+}
+
+function renderWidgets(interimHTML, variables) {
+  const engine = buildEngine(variables);
+  const renderedHTML = engine.parseAndRenderSync(interimHTML);
+  return renderedHTML;
 }
 
 export default renderWidgets;

--- a/_config.yml
+++ b/_config.yml
@@ -157,6 +157,10 @@ defaults:
       path: "admin/"
     values:
       sitemap: false
+  - scope:
+      path: "_includes/"
+    values:
+      sitemap: false
 
 languages: ["en"]
 default_lang: "en"
@@ -207,6 +211,7 @@ assets:
     - source: _pdfs/*
     - source: _assets/images/*
       strip: _assets/
+    - source: _includes/**/*
   sources:
     - node_modules/anchor-js
     - node_modules/gumshoejs/dist

--- a/_config.yml
+++ b/_config.yml
@@ -165,6 +165,7 @@ parallel_localization: true
 
 include:
   - _pages
+  - _includes
 
 exclude:
   - package.json

--- a/_plugins/site_json.rb
+++ b/_plugins/site_json.rb
@@ -1,0 +1,23 @@
+require 'yaml'
+
+module Jekyll
+  # Makes the site variable available to Javascript via a script tag.
+  # Meant to be used in the admin code - this includes quite a bit of data that
+  # won't be performant or necessary for public use.
+
+  class SiteJsonTag < Liquid::Tag
+    def render(context)
+      site = YAML.load_file('_config.yml')
+      data = context.registers[:site].to_liquid[:site]['data'].to_h
+      site['data'] = data
+
+      <<~EOS
+        <script>
+          window.jekyllSite = #{site.to_json};
+        </script>
+      EOS
+    end
+  end
+end
+
+Liquid::Template.register_tag('site_json', Jekyll::SiteJsonTag)

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -43,7 +43,7 @@ collections:
   # Pages:
   - label: Pages
     name: pages
-    summary: "{{filename}} ({{title}})"
+    summary: "{{title}} ({{filename}})"
     files:
     # 404 error page:
       - label: "404"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -43,6 +43,7 @@ collections:
   # Pages:
   - label: Pages
     name: pages
+    summary: "{{filename}} ({{title}})"
     files:
     # 404 error page:
       - label: "404"
@@ -279,7 +280,7 @@ collections:
           widget: markdown
       # Resources page:
       - label: Resources
-        name: Resources
+        name: resources
         file: _pages/resources.md
         fields:
         - label: Permalink
@@ -298,6 +299,7 @@ collections:
     # Topic pages:
   - label: Topics
     name: topics
+    summary: "{{filename}} ({{title}})"
     folder: _pages/_topics
     create: true
     fields:
@@ -368,6 +370,7 @@ collections:
   # Resources pages:
   - label: Resources
     name: resources
+    summary: "{{filename}} ({{title}})"
     folder: _pages/_resources
     create: true
     fields:
@@ -452,6 +455,7 @@ collections:
     # Laws and regulations pages
   - label: Law and Regs
     name: law-and-regs
+    summary: "{{filename}} ({{title}})"
     folder: _pages/law-and-regs
     create: true
     fields:
@@ -488,6 +492,7 @@ collections:
   # Design standards pages
   - label: Design Standards
     name: design-standards
+    summary: "{{filename}} ({{title}})"
     folder: _pages/law-and-regs/design-standards
     create: true
     fields:
@@ -524,6 +529,7 @@ collections:
     # Posts under the Notices pages
   - label: Notices
     name: notices-posts
+    summary: "{{filename}} ({{title}})"
     folder: notices/_posts
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
@@ -537,6 +543,7 @@ collections:
   # Spanish Translations
   - label: Español
     name: es
+    summary: "{{filename}} ({{title}})"
     folder: _pages/es/
     create: true
     fields:

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,6 +1,7 @@
 ---
 layout: null
 ---
+
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,6 +11,7 @@ layout: null
     <title>ADA Content Manager</title>
   </head>
   <body>
+    {% site_json %}
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
     <script
@@ -20,7 +22,7 @@ layout: null
     ></script>
     {% asset dist/netlifyPreview-compiled.js %}
     <script>
-      CMS.registerPreviewStyle('{% asset styles.css @path %}')
+      CMS.registerPreviewStyle('{% asset styles.css @path %}');
     </script>
     <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url" />
     <style>
@@ -32,5 +34,6 @@ layout: null
         margin-top: 0px !important;
       }
     </style>
+
   </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -6,6 +6,7 @@ layout: null
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="{% asset 'favicon.png' @path %}" />
     <title>ADA Content Manager</title>
   </head>
   <body>


### PR DESCRIPTION
cc: @vwilliamsn @c2nelson 

# What is this?

This adds support for rending HTML includes.

# Limitations

It turns out a lot of the includes depend on _site variables_, such as what other posts exist and what those posts include. For example, to render news items, you need to know what news pages exist. That's something netlify doesn't know about, because netlify only cares about the current page.

Because those exist in the Jekyll context prior to loading our site, it's not possible (or at least, it's very difficult) to include a version of those variables for Netlify to parse. This means that includes which depend on other components (like the news feature) will fail to load.

Some of the listed includes also depend on _layouts_ being supported, but we don't support them yet. The includes themselves should work, but we can't actually preview them in netlify to check (e.g., back to top)

# Proof it works:

Here's a list of the includes from the ticket as AC's:

- [x] landing hero

![hero](https://user-images.githubusercontent.com/15126660/229861562-57b3b629-4541-46c4-b4a6-6e755b945a12.gif)

- [x] landing learn

![learn](https://user-images.githubusercontent.com/15126660/229862115-a0151e6c-68ca-4367-9d91-1a330de24db1.gif)

- [x] landing report

![report](https://user-images.githubusercontent.com/15126660/229861609-c5c8e0de-84db-49ed-9af6-507ac0e5f3c6.gif)

- [x] landing service-animals

Note: images are broken pending future work.

<img width="720" alt="image" src="https://user-images.githubusercontent.com/15126660/229861768-a6ec370b-c855-404a-8717-da7cf22825bc.png">

- [ ] news-item

This turned out to be hard, as it depends on other site content to render.

- [ ] card

This turned out to be hard, as it depends on "topics" existing on the site object.

- [x] download-pdf

<img width="1485" alt="image" src="https://user-images.githubusercontent.com/15126660/229863879-479ca582-28b4-4a24-84e8-135fed57717b.png">

- [x] expand-accordions-button
- [x] expand-accordions-wrapper

Note that for these, the 'expandable' text is due to the not-yet-implemented "details" widget:

![expand](https://user-images.githubusercontent.com/15126660/229873715-587a852d-12ea-4859-9419-a6c514a26e6e.gif)

- [x] print-button

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/15126660/229873941-a342f3a3-869e-419d-838b-2a77d0188157.png">

- [ ] back-to-top

This depends on us rendering `layouts` for the pages.