### PR TITLE
Make site-wide info available to Netlify

### DIFF
--- a/_assets/js/netlify/loadSiteData.js
+++ b/_assets/js/netlify/loadSiteData.js
@@ -1,0 +1,15 @@
+/** Modifies window.jekyllSite to contain site data from a few sources. */
+export default async function loadSiteData() {
+  const response = await fetch('/site.json');
+  const siteData = await response.json();
+  Object.assign(window.jekyllSite, siteData);
+  Object.assign(window.jekyllSite, getLocalSite());
+}
+
+/** Some of the jekyll site variables depend on browser context. */
+function getLocalSite() {
+  return {
+    'baseurl': window.location.origin,
+    'active_lang': 'en',
+  };
+}

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -1,5 +1,6 @@
 import generatePageData from './generatePageData';
 import makeTemplate from './makeTemplate';
+import loadSiteData from './loadSiteData';
 
 const preview = createClass({
   render: function () {
@@ -7,6 +8,8 @@ const preview = createClass({
     return makeTemplate(pageData);
   },
   });
+
+await loadSiteData();
 
 const pages = [
   'index',

--- a/_assets/js/netlify/renderMdWidgets.js
+++ b/_assets/js/netlify/renderMdWidgets.js
@@ -71,7 +71,8 @@ function buildEngine(globals, imageData) {
             break;
           case 'asset':
             const valArr = renderedValue.split(' ');
-            const imagePathArr = valArr[0].split('/');
+            const imagePathRaw = valArr[0].replaceAll(/(^')|('$)/g, '');
+            const imagePathArr = imagePathRaw.split('/');
             const imageTitle = imagePathArr[imagePathArr.length - 1];
             const imagePath = getImagePath(imageTitle, imageData);
             return `<img src="${imagePath}">`;

--- a/_assets/js/netlify/renderMdWidgets.js
+++ b/_assets/js/netlify/renderMdWidgets.js
@@ -163,6 +163,7 @@ function renderWidgets(interimHTML, variables, imageData) {
   const engine = buildEngine({
     'page': variables,
     'site': window.jekyllSite,  // This is defined globally via site_json.rb
+    'lang': 'en',
   }, imageData);
   const renderedHTML = engine.parseAndRenderSync(interimHTML);
   return renderedHTML;

--- a/_assets/js/netlify/renderMdWidgets.js
+++ b/_assets/js/netlify/renderMdWidgets.js
@@ -51,9 +51,11 @@ function buildEngine(globals, imageData) {
         }
       },
       *render(context, emitter) {
+        // It's possible to use templating inside of tags, so resolve that first:
+        const renderedValue = this.liquid.parseAndRenderSync(this.value, context, emitter);
         switch (tagName) {
           case 'accordion':
-            const options = this.value.split(' ');
+            const options = renderedValue.split(' ');
             const accId = `accordion-${options[0].trim()}`;
             const multiselect = options.includes('multiselect');
             const expandable = options.includes('expandable');
@@ -68,7 +70,7 @@ function buildEngine(globals, imageData) {
             emitter.write('</div>');
             break;
           case 'asset':
-            const valArr = this.value.split(' ');
+            const valArr = renderedValue.split(' ');
             const imagePathArr = valArr[0].split('/');
             const imageTitle = imagePathArr[imagePathArr.length - 1];
             const imagePath = getImagePath(imageTitle, imageData);
@@ -92,7 +94,7 @@ function buildEngine(globals, imageData) {
             emitter.write('</div>');
             break;
           case 'details':
-            const detailTitle = yield this.value;
+            const detailTitle = yield renderedValue;
             emitter.write(
               `<details data-detail-open='false'><summary><div><span class='pa11y-skip'>${detailTitle}</span></div></summary><div><p>`
             );
@@ -105,7 +107,7 @@ function buildEngine(globals, imageData) {
             emitter.write('</figcaption>');
             break;
           case 'figure':
-            const figTitle = this.value;
+            const figTitle = renderedValue;
             const figId = title.toLowerCase().trim().replaceAll(/\s/g, '');
             emitter.write(`<figure id=${figId}>
                  <strong>${figTitle}</strong><br/>`);
@@ -113,10 +115,10 @@ function buildEngine(globals, imageData) {
             emitter.write('</figure>');
             break;
           case 'fn':
-            const fnId = this.value;
+            const fnId = renderedValue;
             return `<sup><a href="#fn:${fnId}" class="footnote" id="fn-back:${fnId}">${fnId}</a></sup>`;
           case 'fnbody':
-            const fnBodyId = this.value.trim();
+            const fnBodyId = renderedValue.trim();
             emitter.write(`<li id='fn:${fnBodyId}' class='footnotebody' value='${fnBodyId}'>`);
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);
             emitter.write(`<a href='#fn-back:${fnBodyId}' class='backlink'>Back to text</a>`);
@@ -127,7 +129,7 @@ function buildEngine(globals, imageData) {
             emitter.write('</ol></div>');
             break;
           case 'list':
-            const listIconType = this.value;
+            const listIconType = renderedValue;
             context._iconType = listIconType;
             emitter.write("<ul class='usa-icon-list margin-bottom-2'>");
             yield this.liquid.renderer.renderTemplates(this.tpls, context, emitter);

--- a/_config.yml
+++ b/_config.yml
@@ -190,6 +190,7 @@ exclude:
   - /mock_data
   - make_redirects.rb
   - /scripts
+  - /node_modules
 
 assets:
   autoprefixer:

--- a/_includes/page.json
+++ b/_includes/page.json
@@ -1,24 +1,24 @@
+{% assign ignored_fields = "date, excerpt, content, next, previous, output" | split: ", " %}
+
 {
-  "title": {{ page.title | jsonify }},
-  "url": {{ page.url | jsonify }},
+  {% for entry in page %}
+
+  {% if entry[0] %}
+    {% assign field = entry[0] %}
+    {% assign value = entry[1] %}
+  {% else %}
+    {% assign field = entry %}
+    {% assign value = page[entry] %}
+  {% endif %}
+
+  {% unless ignored_fields contains field }} %}
+  {% if field %}
+    {{ field | jsonify }}: {{ value | jsonify }},
+  {% endif %}
+  {% endunless %}
+
+  {% endfor %}
+
   "date": "{{ page.date | date_to_xmlschema }}",
-  "id": {{ page.id | jsonify }},
-  "categories": {{ page.categories | jsonify }},
-  "collection": {{ page.collection | jsonify }},
-  "tags": {{ page.tags | jsonify }},
-  "dir": {{ page.dir | jsonify }},
-  "name": {{ page.name | jsonify }},
-  "path": {{ page.path | jsonify }},
-
-  {% comment %}
-    Content is very large, tricky to escape, and we don't use it:
-  {% endcomment %}
   "content": "Empty content for Netlify"
-
-  {% comment %}
-    These fields are explicitly excluded:
-    "excerpt": page.excerpt,
-    "next": page.next,
-    "previous": page.previous",
-  {% endcomment %}
 }

--- a/_includes/page.json
+++ b/_includes/page.json
@@ -1,0 +1,24 @@
+{
+  "title": {{ page.title | jsonify }},
+  "url": {{ page.url | jsonify }},
+  "date": "{{ page.date | date_to_xmlschema }}",
+  "id": {{ page.id | jsonify }},
+  "categories": {{ page.categories | jsonify }},
+  "collection": {{ page.collection | jsonify }},
+  "tags": {{ page.tags | jsonify }},
+  "dir": {{ page.dir | jsonify }},
+  "name": {{ page.name | jsonify }},
+  "path": {{ page.path | jsonify }},
+
+  {% comment %}
+    Content is very large, tricky to escape, and we don't use it:
+  {% endcomment %}
+  "content": "Empty content for Netlify"
+
+  {% comment %}
+    These fields are explicitly excluded:
+    "excerpt": page.excerpt,
+    "next": page.next,
+    "previous": page.previous",
+  {% endcomment %}
+}

--- a/site.json
+++ b/site.json
@@ -3,32 +3,34 @@ layout: null
 ---
 {
   "pages": [
-    {%- for page in site.pages -%}
-      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
+    {% for page in site.pages %}
+      {% include page.json page=page %}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
   ],
   "posts": [
-    {%- for page in site.posts -%}
-      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
+    {% for page in site.posts %}
+      {% include page.json page=page %}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
   ],
   "topics": [
-    {%- for page in site.topics -%}
-      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
+    {% for page in site.topics %}
+      {% include page.json page=page %}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
   ],
   "resources": [
-    {%- for page in site.resources -%}
-      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
+    {% for page in site.resources %}
+      {% include page.json page=page %}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
   ],
   "categories": {
-    {%- for category in site.categories -%}
+    {% for category in site.categories %}
+    {% if category[0] %}
     {{ category[0] | jsonify }}: [
-      {%- for page in category[1] -%}
-        {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
-      {%- endfor -%}
-    ]{%- unless forloop.last -%},{%- endunless -%}
-    {%- endfor -%}
+      {% for page in category[1] %}
+        {% include page.json page=page %}{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ]{% unless forloop.last %},{% endunless %}
+    {% endif %}
+    {% endfor %}
   }
 }

--- a/site.json
+++ b/site.json
@@ -1,0 +1,34 @@
+---
+layout: null
+---
+{
+  "pages": [
+    {%- for page in site.pages -%}
+      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ],
+  "posts": [
+    {%- for page in site.posts -%}
+      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ],
+  "topics": [
+    {%- for page in site.topics -%}
+      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ],
+  "resources": [
+    {%- for page in site.resources -%}
+      {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ],
+  "categories": {
+    {%- for category in site.categories -%}
+    {{ category[0] | jsonify }}: [
+      {%- for page in category[1] -%}
+        {%- include page.json page=page -%}{%- unless forloop.last -%},{%- endunless -%}
+      {%- endfor -%}
+    ]{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  }
+}


### PR DESCRIPTION
# What does this change?

Exposes site information to netlify - see the screenshots for an example of what this enables.

- 🌎 Right now, Netlify only gets information about the current page. It
  doesn't know about other pages.
- ⛔ This isn't great because some pages (such as the news widget, or
  featured topics widget) require knowledge about other pages on the
  site to render.
- ✅ This PR exports as much site data as we can reasonably export
  to Netlify.

Also fixes a bug:

- 🌎 Sometimes quotes exist in variable image paths
- ⛔ Our code wasn't accounting for that
- ✅ This commit trims the quotes

More of a note-to-self, here's the sheet I used to evaluate whether I got all of the places we use site information:

[Site Vars Support.xlsx](https://github.com/usdoj-crt/beta-ada/files/11389747/Site.Vars.Support.xlsx)

# Proof it Works

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/15126660/236009727-8a25b65c-a7c0-4f5a-a322-f2aa06b56ff5.png">

![topics](https://user-images.githubusercontent.com/15126660/236009789-bffa8831-1b23-4685-b3c0-59ac68e9309c.gif)