### PR TITLE
Don't stop rendering on template failures.

### DIFF
--- a/_assets/js/netlify/makeError.js
+++ b/_assets/js/netlify/makeError.js
@@ -1,0 +1,28 @@
+import generateChildElements from './generateChildElements';
+import formatPublishDates from './formatPublishDates';
+
+/** @jsx h */
+
+function makeError(error) {
+  return (
+    <div
+      id="crt-page--content"
+      className="admin-error-conatiner mobile-lg:grid-col tablet:grid-col-12 desktop:grid-col-8"
+    >
+      <h1 className="admin-error-highlight">ADA.gov Admin Error</h1>
+      <div className="measure-6">
+        <div className="crt-lead">
+          <p>Couldn't render the template:</p>
+          <code>{error.name} ({error.message})</code>
+          <p>Please edit the code on the left and try again</p>
+          <p>Full details:</p>
+          <code>{error.stack}</code>
+        </div>
+
+
+      </div>
+    </div>
+  );
+};
+
+export default makeError;

--- a/_assets/js/netlify/makeTemplate.js
+++ b/_assets/js/netlify/makeTemplate.js
@@ -5,7 +5,7 @@ import formatPublishDates from './formatPublishDates';
 
 function makeTemplate(data) {
   const { previewLink, title, leadText, body, publishDate, updatedDate, print, pdf, relatedContent } = data;
-  const pageTemplate = (
+  return (
     <div
       id="crt-page--content"
       className="mobile-lg:grid-col tablet:grid-col-12 desktop:grid-col-8"
@@ -62,7 +62,6 @@ function makeTemplate(data) {
       </div>
     </div>
   );
-  return pageTemplate;
 };
 
 export default makeTemplate;

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -1,11 +1,16 @@
 import generatePageData from './generatePageData';
 import makeTemplate from './makeTemplate';
+import makeError from './makeError';
 import loadSiteData from './loadSiteData';
 
 const preview = createClass({
   render: function () {
-    const pageData = generatePageData(this.props.entry);
-    return makeTemplate(pageData);
+    try {
+      const pageData = generatePageData(this.props.entry);
+      return makeTemplate(pageData);
+    } catch (error) {
+      return makeError(error);
+    }
   },
   });
 


### PR DESCRIPTION
- 🌎 The netlify system breaks entirely if a template is invalid.
- ⛔ This isn't great because as you're typing a template out, it's invalid.
- ✅ This commit catches those exceptions and displays them nicely.

![example](https://github.com/usdoj-crt/beta-ada/assets/15126660/a62388c1-0a2a-42d6-a9c8-425400d4e1b1)
