### PR TITLE
Turn off pa11y color-contrast

### DIFF
--- a/.pa11yci-desktop
+++ b/.pa11yci-desktop
@@ -8,6 +8,9 @@
     "hideElements": ["#fba-button", ".pa11y-skip", "#fba-modal-dialog"],
     "standard": "WCAG2AA",
     "runners": ["axe"],
+    "ignore": [
+      "color-contrast"
+    ],
     "timeout": 240000
   }
 }


### PR DESCRIPTION
We've been getting too many false alarms. I'd previously turned off mobile, but desktop is acting up, too.

See: github.com/pa11y/pa11y/issues/633