### PR TITLE
Add sitemap page and remove redirect to archive site

### DIFF
--- a/_data/generated_redirects.json
+++ b/_data/generated_redirects.json
@@ -8151,7 +8151,6 @@
   "/sierra-vista/sierra_vista_attj.htm": "https://archive.ada.gov/sierra-vista/sierra_vista_attj.htm",
   "/sierra-vista/sierra_vista_sa.htm": "https://archive.ada.gov/sierra-vista/sierra_vista_sa.htm",
   "/siouxland_dq.html": "https://archive.ada.gov/siouxland_dq.html",
-  "/site_map.htm": "https://archive.ada.gov/site_map.htm",
   "/sjh_lof.html": "https://archive.ada.gov/sjh_lof.html",
   "/skeete_cd/skeete_CD.htm": "https://archive.ada.gov/skeete_cd/skeete_CD.htm",
   "/skeete_cd/skeete_complaint.htm": "https://archive.ada.gov/skeete_cd/skeete_complaint.htm",

--- a/_includes/sitemap-pages.html
+++ b/_includes/sitemap-pages.html
@@ -1,0 +1,51 @@
+{% assign pageArray = '' | split: '' %}
+{% assign topicPageArray = '' | split: '' %}
+{% assign resourcePageArray = '' | split: '' %}
+{% assign lawPageArray = '' | split: '' %}
+{% assign pages=site.pages %} {% assign posts=site.posts %}
+{% assign topics=site.topics %}
+{% assign resources=site.resources %}
+{% assign pages = pages | concat: posts | concat: topics | concat: resources %}
+{% for page in pages %}
+    {% if page.sitemap!=false and page.title!=nil %}
+        {% if page.permalink contains '/topics/' %}
+            {% assign topicPageArray = topicPageArray | push:page | sort:"permalink" %}
+        {% elsif page.permalink contains '/resources/' %}
+            {% assign resourcePageArray = resourcePageArray| push:page | sort:"permalink" %}
+        {% elsif page.permalink contains '/law-and-regs/' %}
+            {% assign lawPageArray = lawPageArray | push:page | sort:"permalink" %}
+        {% else %}
+            {% assign pageArray = pageArray | push:page %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
+<ul class="usa-list usa-list--unstyled">
+{% for page in pageArray %}
+    <li><h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3></li>
+{% endfor %}
+
+    {% for topic in topicPageArray %}
+        {% if topic.permalink == '/topics/' %}
+        <li><h3><a href="{{ topic.permalink }}">{{ topic.title }}</a></h3></li>
+        {% else %}
+        <li class="margin-left-2"><a href="{{ topic.permalink }}">{{ topic.title }}</a></li>
+        {% endif %}
+    {% endfor %}
+
+    {% for resource in resourcePageArray %}
+    {% if resource.permalink == '/resources/' %}
+        <li><h3><a href="{{ resource.permalink }}">{{ resource.title }}</a></h3></li>
+    {% else %}
+        <li class="margin-left-2"><a href="{{ resource.permalink }}">{{ resource.title }}</a></li>
+    {% endif %}
+    {% endfor %}
+
+    {% for law in lawPageArray %}
+    {% if law.permalink == '/law-and-regs/' %}
+        <li><h3><a href="{{ law.permalink }}">{{ law.title }}</a></h3></li>
+    {% else %}
+        <li class="margin-left-2"><a href="{{ law.permalink }}">{{ law.title }}</a></li>
+    {% endif %}
+    {% endfor %}
+</ul>

--- a/_pages/redirects/site_map.md
+++ b/_pages/redirects/site_map.md
@@ -1,5 +1,0 @@
----
-sitemap: false 
-redirect_from: /site_map.htm 
-redirect_to: https://archive.ada.gov/site_map.htm 
----

--- a/_pages/site_map.md
+++ b/_pages/site_map.md
@@ -1,0 +1,9 @@
+---
+permalink: /site_map/
+title: Sitemap
+sitemap: false
+sidenav: false
+---
+
+{% include sitemap-pages.html %}
+


### PR DESCRIPTION
Currently www.ada.gov/site_map redirects to the archive site. This PR adds a sitemap page on the new site and removes the redirect.