### PR TITLE
Add GA click events to navigation elements

### DIFF
--- a/_assets/js/utils/gaUtil.js
+++ b/_assets/js/utils/gaUtil.js
@@ -1,5 +1,8 @@
-function sendGAClickEvent(event_name) {
-    gtag('event', 'click', { event_name: event_name });
+function sendGAClickEvent(e) {
+  e.preventDefault();
+  const event_name = e.target.ariaLabel + ' ' + e.target.innerText;
+  gtag('event', 'click', { event_name: event_name });
+  window.location.href = e.target.href;
 }
 
 function gtag() {
@@ -10,7 +13,26 @@ function gtag() {
 export default function initGAEvents() {
   const infoBoxLinks = document.getElementsByClassName("info-box-link");
   Array.from(infoBoxLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent(el.innerText));
+    el.addEventListener('click', sendGAClickEvent);
   });
-  relatedReportButton.addEventListener('click', sendGAClickEvent('view related reports'));
+  const relatedContentLinks = document.getElementsByClassName("related-content-link");
+  Array.from(relatedContentLinks).forEach((el) => {
+    el.addEventListener('click', sendGAClickEvent);
+  });
+  const alertLinks = document.getElementsByClassName("alert-link");
+  Array.from(alertLinks).forEach((el) => {
+    el.addEventListener('click', sendGAClickEvent);
+  });
+  const topicCardLinks = document.getElementsByClassName("topic-card__link");
+  Array.from(topicCardLinks).forEach((el) => {
+    el.addEventListener('click', sendGAClickEvent);
+  });
+  const learnLinks = document.getElementsByClassName("learn-link");
+  Array.from(learnLinks).forEach((el) => {
+    el.addEventListener('click', sendGAClickEvent);
+  });
+  const sideNavLinks = document.getElementsByClassName("crt-sidenav-subnav-item");
+  Array.from(sideNavLinks).forEach((el) => {
+    el.addEventListener('click', sendGAClickEvent);
+  });
 }

--- a/_assets/js/utils/gaUtil.js
+++ b/_assets/js/utils/gaUtil.js
@@ -1,6 +1,8 @@
 function sendGAClickEvent(e) {
   e.preventDefault();
-  const event_name = e.target.ariaLabel + ' ' + e.target.innerText;
+  const ariaLabel = e.target.ariaLabel ?? 'unlabeled link element';
+  const innerText = e.target.innerText ?? 'empty link element';
+  const event_name = ariaLabel + ' ' + innerText;
   gtag('event', 'click', { event_name: event_name });
   window.location.href = e.target.href;
 }
@@ -10,29 +12,19 @@ function gtag() {
   dataLayer.push(arguments);
 }
 
-export default function initGAEvents() {
-  const infoBoxLinks = document.getElementsByClassName("info-box-link");
-  Array.from(infoBoxLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-  const relatedContentLinks = document.getElementsByClassName("related-content-link");
-  Array.from(relatedContentLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-  const alertLinks = document.getElementsByClassName("alert-link");
-  Array.from(alertLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-  const topicCardLinks = document.getElementsByClassName("topic-card__link");
-  Array.from(topicCardLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-  const learnLinks = document.getElementsByClassName("learn-link");
-  Array.from(learnLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-  const sideNavLinks = document.getElementsByClassName("crt-sidenav-subnav-item");
-  Array.from(sideNavLinks).forEach((el) => {
-    el.addEventListener('click', sendGAClickEvent);
-  });
-}
+  const ANALYTICS_CONFIG = [
+    ['.related-content-link', 'click', sendGAClickEvent],
+    ['.alert-link', 'click', sendGAClickEvent],
+    ['.topic-card__link', 'click', sendGAClickEvent],
+    ['.learn-link', 'click', sendGAClickEvent],
+    ['.crt-sidenav-subnav-item', 'click', sendGAClickEvent],
+    ['.info-box-link', 'click', sendGAClickEvent],
+  ]
+  
+  export default function initGAEvents() {
+    ANALYTICS_CONFIG.forEach(([selector, event, action]) => {
+      document.querySelectorAll(selector).forEach(el => {
+        el.addEventListener(event, action);
+      });
+    });
+  }

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -25,6 +25,7 @@
     <div class="usa-card__footer">
       {% if include.card.card.href %}
       <a
+        class="topic-card__link"
         href="{{ include.card.card.href | relative_url }}"
         aria-label="Learn more about {{include.card.card.title_alt | default:include.card.card.title}}"
         >{{site.data[lang]["i18n"].links.learn}}</a

--- a/_includes/landing/learn.html
+++ b/_includes/landing/learn.html
@@ -35,7 +35,7 @@
                   <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
-                        <a class="text-white learn-link" aria-label="learn link" href="{{example.link | relative_url }}">
+                        <a class="text-white learn-link" aria-label="learn more example link" href="{{example.link | relative_url }}">
                             {{ example.title }}
                         </a>
                     </li>

--- a/_includes/landing/learn.html
+++ b/_includes/landing/learn.html
@@ -35,7 +35,7 @@
                   <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
-                        <a class="text-white" href="{{example.link | relative_url }}">
+                        <a class="text-white learn-link" aria-label="learn link" href="{{example.link | relative_url }}">
                             {{ example.title }}
                         </a>
                     </li>

--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -8,7 +8,8 @@
       <h3 class="usa-alert__heading pa11y-skip">{% if lang=="en" %}{{ post.notice_text }}{% elsif lang=="es" %}{{post.notice_text_es}}{% endif %}</h3>
       <p class="usa-alert__text">
         <a
-          class="pa11y-skip"
+          aria-label="alert link"
+          class="pa11y-skip alert-link"
           href="{{ post.url | relative_url }}"
           >{% if lang=="en" %}{{ post.notice_link }}{% elsif lang=="es" %}{{post.notice_link}}{% endif %}</a
         >

--- a/_includes/page-type-info-box.html
+++ b/_includes/page-type-info-box.html
@@ -47,13 +47,13 @@
 
         <ul class="no-bullets">
           {% unless pageType == 'topics' %}
-          <li>For a beginner-level introduction to a topic, view <a class="usa-summary-box__link info-box-link" href="/topics">Featured Topics</a></li>
+          <li>For a beginner-level introduction to a topic, view <a class="usa-summary-box__link info-box-link" href="/topics" aria-label="info box link">Featured Topics</a></li>
           {% endunless %}
           {% unless pageType == 'resources' %}
-          <li>For more detailed information on a topic, view <a class="usa-summary-box__link info-box-link" href="/resources{{ filters }}">Guidance & Resource materials</a></li>
+          <li>For more detailed information on a topic, view <a class="usa-summary-box__link info-box-link" href="/resources{{ filters }}" aria-label="info box link">Guidance & Resource materials</a></li>
           {% endunless %}
           {% unless pageType == 'law-and-regs' %}
-          <li>For information about the legal requirements, visit <a class="usa-summary-box__link info-box-link" href="/law-and-regs">Laws, Regulations & Standards</a></li>
+          <li>For information about the legal requirements, visit <a class="usa-summary-box__link info-box-link" href="/law-and-regs" aria-label="info box link">Laws, Regulations & Standards</a></li>
           {% endunless %}
         </ul>
       </div>

--- a/_includes/related-content.html
+++ b/_includes/related-content.html
@@ -67,7 +67,7 @@
         </h4>
 
         <div class="margin-1">
-          <a class="usa-summary-box__link" href="{{ link.url | relative_url }}">{{ link.title }}</a>
+          <a class="usa-summary-box__link related-content-link" aria-label="related content link" href="{{ link.url | relative_url }}">{{ link.title }}</a>
         </div>
       </div>
     </div>

--- a/_includes/subnav.html
+++ b/_includes/subnav.html
@@ -17,7 +17,7 @@
   </li>
   {% else %}
   <li class="usa-sidenav__item">
-    <a class="crt-sidenav-subnav-item" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+    <a class="crt-sidenav-subnav-item" aria-label="side nav link" href="{{ item.url | relative_url }}">{{ item.title }}</a>
   </li>
   {% endif %}
   {% endfor %} {% else %} {% for item in include.collection %}


### PR DESCRIPTION
This PR adds more click events to measure user interaction with home page navigation elements, topic cards, related content boxes, etc.