### PR TITLE
Speed up development by disabling redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This site requires Ruby and Node.js in order to run locally. For guidance on ins
     $ bundle install
     $ npm start
 
+Note that running `npm start` will disable some features of the site for performance reasons. See _config.dev.yml, or search for jekyll.environment or Jekyll.env for details.
+
 To build but not serve the site, run `npm run build`.
 
 #### With Docker: UNDER CONSTRUCTION

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,0 +1,22 @@
+exclude: # Be sure to add new excludes to _config.yml as well!
+  - package.json
+  - package-lock.json
+  - README.md
+  - CONTRIBUTING.md
+  - LICENSE.md
+  - Dockerfile
+  - docker-compose.yml
+  - babel.config.json
+  - webpack.javascript.js
+  - webpack.sass.js
+  - playwright.config.js
+  - /docs
+  - /tests
+  - /test-results
+  - /playwright-report
+  - /mock_data
+  - make_redirects.rb
+  - /scripts
+  - /node_modules
+  # The following are only excluded from the dev workflow:
+  - _pages/redirects

--- a/_config.yml
+++ b/_config.yml
@@ -171,7 +171,7 @@ include:
   - _pages
   - _includes
 
-exclude:
+exclude: # Be sure to add new excludes to _config.dev.yml as well!
   - package.json
   - package-lock.json
   - README.md

--- a/_plugins/redirect_json.rb
+++ b/_plugins/redirect_json.rb
@@ -38,6 +38,11 @@ module RedirectsJson
     priority :highest
 
     def generate(site)
+      # Don't run this on development for performance reasons:
+      if Jekyll.env == 'development'
+        return
+      end
+
       # Merging in this order will overwrite entries in generated_redirects
       # with entries from manual_redirects
       #

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:js": "prettier --check \"_assets/js/**/*.js\"",
     "start:js": "NODE_ENV=development webpack --config webpack.javascript.js --progress --watch",
     "start:sass": "webpack --config webpack.sass.js --progress --watch",
-    "start": "npm run start:sass & npm run start:js & bundle exec jekyll serve --livereload --trace",
+    "start": "npm run start:sass & npm run start:js & bundle exec jekyll serve --livereload --trace --config _config.yml,_config.dev.yml",
     "test:a11y-desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://127.0.0.1:4000/sitemap.xml",
     "test:a11y-mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://127.0.0.1:4000/sitemap.xml",
     "test:ui": "npm run start:js & bundle exec jekyll serve --detach && playwright test"


### PR DESCRIPTION
Note: This only affects the development workflow.

- 🌎 We build the entire site when live reloading in development
- ⛔ Right now this takes ~50 seconds (for me).
- ✅ This commit removes redirects (generated and the redirect
  directory) from dev compilation, which speeds up compilation to ~16
  seconds)
- 🔮 Future commits will further debug our sass compilation time, which
  is 8 of the remaining 16 seconds.