### PR TITLE
Add expand all button to sidenav

### DIFF
--- a/_assets/js/expand-sidenav.js
+++ b/_assets/js/expand-sidenav.js
@@ -1,0 +1,32 @@
+const sidenav = () => {
+    const expandButton = document.getElementById('expand-all');
+
+    function expandAll(e) {
+        const submenuButtons = document.getElementsByClassName('usa-accordion__button');
+        if (e.target.innerText === 'Expand all') {
+            Array.from(submenuButtons).forEach(button => {
+                const isExpanded = button.getAttribute('aria-expanded') === "true";
+                if (!isExpanded) {
+                    button.click();
+                }
+            });
+            e.target.innerText = 'Collapse all';
+        } else {
+            Array.from(submenuButtons).forEach(button => {
+                const isExpanded = button.getAttribute('aria-expanded') === "true";
+                if (isExpanded) {
+                    button.click();
+                }
+            });
+            e.target.innerText = 'Expand all';
+        }
+    }
+
+    if (expandButton) {
+        expandButton.addEventListener('click', function(e){
+            expandAll(e);
+        });
+    }
+}
+
+export default sidenav;

--- a/_assets/js/expand-sidenav.js
+++ b/_assets/js/expand-sidenav.js
@@ -3,23 +3,13 @@ const sidenav = () => {
 
     function expandAll(e) {
         const submenuButtons = document.getElementsByClassName('usa-accordion__button');
-        if (e.target.innerText === 'Expand all') {
-            Array.from(submenuButtons).forEach(button => {
-                const isExpanded = button.getAttribute('aria-expanded') === "true";
-                if (!isExpanded) {
-                    button.click();
-                }
-            });
-            e.target.innerText = 'Collapse all';
-        } else {
-            Array.from(submenuButtons).forEach(button => {
-                const isExpanded = button.getAttribute('aria-expanded') === "true";
-                if (isExpanded) {
-                    button.click();
-                }
-            });
-            e.target.innerText = 'Expand all';
-        }
+        expandingAll = e.target.innerText === 'Expand all';
+        Array.from(submenuButtons).forEach(button => {
+            const isExpanded = button.getAttribute('aria-expanded') === "true";
+            if (!isExpanded && expandingAll) button.click();
+            if (isExpanded && !expandingAll) button.click();
+        });
+        e.target.innerText = expandingAll ? 'Collapse all' : 'Expand all';
     }
 
     if (expandButton) {

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -6,6 +6,7 @@ import redirectModal from "./redirect-modal";
 import printButton from "./print-button";
 import print from "./print";
 import search from "./search";
+import sidenav from "./expand-sidenav";
 
 modal();
 redirectModal();
@@ -13,6 +14,7 @@ print();
 printButton();
 search();
 initGAEvents();
+sidenav();
 
 const anchors = new AnchorJS();
 anchors.add(".crt-page h2:not([class*='usa']) h2:not(.noAnchor)");

--- a/_includes/expand-button.html
+++ b/_includes/expand-button.html
@@ -1,0 +1,1 @@
+<button style="width: max-content" class="usa-button desktop:margin-top-3 margin-bottom-2 bg-primary-darker" id="expand-all">Expand all</button>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,6 +23,7 @@ layout: default
       {% include sidenav.html collection=page.subnav %}
       </div>
       {% endif %}
+      {% include expand-button.html %}
       {% if page.print %}
         {% include print-button.html %}
       {% endif %}


### PR DESCRIPTION
This PR adds an expand all button to the sidenav to enable viewing all the submenus at once.

![image](https://github.com/usdoj-crt/beta-ada/assets/18104884/129e240f-b24e-4111-a2ea-5774f5348d88)
<img width="294" alt="Screenshot 2023-06-23 at 12 54 48 PM" src="https://github.com/usdoj-crt/beta-ada/assets/18104884/ff38ed5b-8117-4a7f-95f7-adfd402bd0b9">
