### PR TITLE
Expand all bug fix

### DIFF
--- a/_assets/js/expand-sidenav.js
+++ b/_assets/js/expand-sidenav.js
@@ -3,7 +3,7 @@ const sidenav = () => {
 
     function expandAll(e) {
         const submenuButtons = document.getElementsByClassName('usa-accordion__button');
-        expandingAll = e.target.innerText === 'Expand all';
+        let expandingAll = e.target.innerText === 'Expand all';
         Array.from(submenuButtons).forEach(button => {
             const isExpanded = button.getAttribute('aria-expanded') === "true";
             if (!isExpanded && expandingAll) button.click();

--- a/_includes/expand-button.html
+++ b/_includes/expand-button.html
@@ -1,1 +1,1 @@
-<button style="width: max-content" class="usa-button desktop:margin-top-3 margin-bottom-2 bg-primary-darker" id="expand-all">Expand all</button>
+<button style="width: max-content" class="usa-button margin-bottom-neg-1 desktop:margin-top-3 bg-primary-darker" id="expand-all">Expand all</button>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,7 +23,9 @@ layout: default
       {% include sidenav.html collection=page.subnav %}
       </div>
       {% endif %}
-      {% include expand-button.html %}
+      {% if page.expand-sidenav %}
+        {% include expand-button.html %}
+      {% endif %}
       {% if page.print %}
         {% include print-button.html %}
       {% endif %}

--- a/_pages/law-and-regs/design-standards/1991-design-standards.md
+++ b/_pages/law-and-regs/design-standards/1991-design-standards.md
@@ -16,6 +16,7 @@ redirect_from:
   - /1991adastandards_index.htm
   - /1991ADAstandards_index.htm
   - /1991standards/1991standards-archive.html
+expand-sidenav: true
 sidenav-pdf:
   title: 1991 ADA Standards for Accessible Design
   filename: 1991-design-standards.pdf

--- a/_pages/law-and-regs/design-standards/2010-stds.md
+++ b/_pages/law-and-regs/design-standards/2010-stds.md
@@ -17,6 +17,7 @@ redirect_from:
   - /regs2010/2010ADAStandards/
   - /2010ADAstandards_index.htm
   - /2010ADAstandards_index/
+expand-sidenav: true
 sidenav-pdf:
   title: 2010 ADA Standards for Accessible Design
   filename: 2010-design-standards.pdf

--- a/_pages/law-and-regs/title-ii-2010-regulations.md
+++ b/_pages/law-and-regs/title-ii-2010-regulations.md
@@ -19,6 +19,7 @@ redirect_from:
 sidenav-pdf:
   title: Americans with Disabilities Act Title II Regulations
   filename: title-ii-2010-regulations.pdf
+expand-sidenav: true
 related-content: true
 tags:
   - title ii

--- a/_pages/law-and-regs/title-iii-regulations.md
+++ b/_pages/law-and-regs/title-iii-regulations.md
@@ -13,6 +13,7 @@ redirect_from:
 sidenav-pdf:
   title: Americans with Disabilities Act Title III Regulations
   filename: title-iii-2010-regulations.pdf
+expand-sidenav: true
 related-content: true
 tags:
   - title iii


### PR DESCRIPTION
This PR addresses a bug where the expand all button was not working and appearing on pages other than the laws and regs/design standards. It also updates the spacing between the expand all button and the other buttons.