### PR TITLE
[Demo] Proof of concept for yes/no form

### DIFF
--- a/_assets/js/yes-no.js
+++ b/_assets/js/yes-no.js
@@ -1,0 +1,55 @@
+function tryToSetPageAnswer() {
+  if (!document.querySelector('#touchpoints-yes-no-form')) return;
+
+  const pageAnswer = document.querySelector('#touchpoints-yes-no-form #answer_02');
+  if (!pageAnswer) {
+    setTimeout(tryToSetPageAnswer, 500);
+    return;
+  }
+
+  pageAnswer.value = window.location.href;
+}
+
+function tryToSetLongFormAnswers(submitButton) {
+  if (!document.querySelector('#touchpoints-yes-no-form')) return;
+
+  const yesno = document.querySelector('#touchpoints-longer-feedback-form #answer_10');
+  const page = document.querySelector('#touchpoints-longer-feedback-form #answer_11');
+  if (!yesno || !page) {
+    setTimeout(tryToSetLongFormAnswers, 500);
+    return;
+  }
+
+  page.value = window.location.href;
+  yesno.value = submitButton.value;
+}
+
+
+function tryToAddResponseListeners() {
+  if (!document.querySelector('#touchpoints-yes-no-form')) return;
+
+  const buttons = document.querySelectorAll(
+    '#touchpoints-yes-no-form #answer_01 input[type="submit"]'
+  );
+  if (buttons.length < 2) {
+    setTimeout(tryToAddResponseListeners, 500);
+    return;
+  }
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      tryToShowLongForm();
+      tryToSetLongFormAnswers(button);
+    });
+  });
+}
+
+function tryToShowLongForm() {
+  const wrapper = document.querySelector('#touchpoints-longer-feedback-form-wrapper');
+  if (!wrapper) return;
+
+  wrapper.hidden = false;
+}
+
+tryToSetPageAnswer();
+tryToAddResponseListeners();

--- a/_assets/sass/custom/_touchpoints.scss
+++ b/_assets/sass/custom/_touchpoints.scss
@@ -76,3 +76,44 @@
   }
 
 }
+
+#touchpoints-yes-no-all-wrapper {
+  padding: 1.25rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  background-color: #d9e8f6;
+
+  .fba-modal-dialog {
+    background-color: #d9e8f6;
+  }
+
+  #touchpoints-longer-feedback-form {
+    .question.white-bg {
+      background: white;
+      border-radius: 5px;
+      margin-bottom: 1em;
+      padding: 1.25em;
+    }
+  }
+
+  #touchpoints-yes-no-form {
+    .question.white-bg {
+      background-color: #d9e8f6;
+    }
+
+    .questions label {
+      display: none;
+    }
+  }
+
+  .usa-button{
+    background-color: color($theme-color-primary-darker);
+    &:hover {
+      background-color: color($theme-link-hover-color) !important;
+    }
+    &:focus {
+      background-color: color($theme-link-hover-color) !important;
+    }
+  }
+
+}

--- a/_config.yml
+++ b/_config.yml
@@ -152,6 +152,7 @@ defaults:
         asset: default-card.png
       layout: "page"
       sidenav: true
+      yesno: true
       featured: false
   - scope:
       path: "admin/"

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -33,6 +33,10 @@
 <script src="https://touchpoints.app.cloud.gov/touchpoints/73c5715c.js" async></script>
 {% endif %}
 
+<script src="https://touchpoints.app.cloud.gov/touchpoints/a09c8a7c.js" async></script> <!-- Was this useful [yes/no] feedback -->
+<script src="https://touchpoints.app.cloud.gov/touchpoints/daf11902.js" async></script> <!-- Long-form feedback -->
+{% asset dist/yesNo-compiled.js %}
+
 {% if page.title == 'Guidance & Resource Materials'%}
 {% asset dist/taResources-compiled.js %}
 {% endif %}

--- a/_includes/touchpoints_yesno.html
+++ b/_includes/touchpoints_yesno.html
@@ -1,0 +1,6 @@
+<div id="touchpoints-yes-no-all-wrapper">
+  <div class="form-wrapper" id="touchpoints-yes-no-form"></div>
+  <div class="form-wrapper" hidden id="touchpoints-longer-feedback-form-wrapper">
+    <div id="touchpoints-longer-feedback-form"></div>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,9 @@
     {% include notice.html %}
     {{ content }}
   </main>
+  {% if page.yesno %}
+    {% include touchpoints_yesno.html %}
+  {% endif %}
   {% include footer.html %}
   {% unless page.back-to-top == nil or page.back-to-top == false  %}
   {% include back-to-top.html %}

--- a/_pages/feedback.md
+++ b/_pages/feedback.md
@@ -6,4 +6,5 @@ lead: |-
     Please tell us how we can make this site better. Thank you.
 lang: "en"
 sidenav: false
+yesno: false
 ---

--- a/_pages/site_map.md
+++ b/_pages/site_map.md
@@ -3,6 +3,7 @@ permalink: /site_map/
 title: Sitemap
 sitemap: false
 sidenav: false
+yesno: false
 ---
 
 {% include sitemap-pages.html %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -325,6 +325,11 @@ collections:
         name: print
         widget: boolean
         required: false
+      - label: Helpful Yes or No
+        name: yesno
+        widget: boolean
+        default: true
+        required: false
       - label: Related Content
         name: related-content
         widget: boolean
@@ -437,6 +442,11 @@ collections:
             widget: string
             required: false
         required: false
+      - label: Helpful Yes or No
+        name: yesno
+        widget: boolean
+        default: true
+        required: false
       - label: Related Content
         name: related-content
         widget: boolean
@@ -477,6 +487,11 @@ collections:
       - label: Body Content
         name: body
         widget: markdown
+      - label: Helpful Yes or No
+        name: yesno
+        widget: boolean
+        default: true
+        required: false
       - label: Related Content
         name: related-content
         widget: boolean
@@ -514,6 +529,11 @@ collections:
       - label: Body Content
         name: body
         widget: markdown
+      - label: Helpful Yes or No
+        name: yesno
+        widget: boolean
+        default: true
+        required: false
       - label: Related Content
         name: related-content
         widget: boolean

--- a/webpack.javascript.js
+++ b/webpack.javascript.js
@@ -11,6 +11,7 @@ module.exports = {
     clickTracking: './_assets/js/click-tracking.js',
     netlifyPreview: './_assets/js/netlify/preview.js',
     redirect404: './_assets/js/redirect404.js',
+    yesNo: './_assets/js/yes-no.js',
   },
   experiments: {
       topLevelAwait: true


### PR DESCRIPTION
@vwilliamsn @kewitham @c2nelson @randyabramson FYI - I'm not adding you as reviewers, but we can use this Pull Request to experiment with the "was this helpful" touchpoints work.

It's also possible to just release the Yes/No form without including the longer feedback form, if we decide to start with that.

# What does this change?

- 🌎 We'd like to get feedback on whether specific pages were helpful.
- ⛔ We have no way of doing that right now.
- ✅ This commit introduces a yes/no prompt and followup form via touchpoints.

(As this is a demo, and will likely require significant changes, I'm not resolving CI/CD failures)

# How to use this?

1. Go to the cloud.gov pages preview URL
2. Scroll to the bottom of a page to find the yes/no form
3. Fill out the feedback forms
4. View responses on touchpoints (requires that I add you to touchpoints)