### PR TITLE
Make Download PDF text configurable

### DIFF
--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -3,6 +3,6 @@
     href="/assets/_pdfs/{{include.filename}}"
     download
     class="usa-button crt-page--downloadpdf-button text-bold"
-    >Download PDF Guidance</a
+    >{% if include.text %}{{include.text}}{% else %}Download PDF{% endif %}</a
   >
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -30,7 +30,7 @@ layout: default
         {% include print-button.html %}
       {% endif %}
       {% if page.sidenav-pdf.title and page.sidenav-pdf.filename %}
-        {% include download-pdf.html filename=page.sidenav-pdf.filename %}
+        {% include download-pdf.html text=page.sidenav-pdf.text filename=page.sidenav-pdf.filename %}
       {% endif %}
     </div>
     {% endif %}

--- a/_pages/_resources/ai-guidance.md
+++ b/_pages/_resources/ai-guidance.md
@@ -13,6 +13,7 @@ print: true
 sidenav-pdf:
   title: Algorithms, Artificial Intelligence, and Disability Discrimination in Hiring
   filename: ai-guidance.pdf
+  text: Download PDF Guidance
 tags:
   - artificial intelligence
   - employment

--- a/_pages/_resources/opioid-use-disorder.md
+++ b/_pages/_resources/opioid-use-disorder.md
@@ -13,6 +13,7 @@ print: true
 sidenav-pdf:
   title: The ADA and Opioid Use Disorder - Combating Discrimination Against People in Treatment or Recovery
   filename: opioid-guidance.pdf
+  text: Download PDF Guidance
 tags:
   - medical care
   - health care

--- a/_pages/_resources/web-guidance.md
+++ b/_pages/_resources/web-guidance.md
@@ -13,6 +13,7 @@ print: true
 sidenav-pdf:
   title: Guidance on Web Accessibility and the ADA
   filename: web-guidance.pdf
+  text: Download PDF Guidance
 tags:
   - web access
   - technology

--- a/_pages/law-and-regs/design-standards/1991-design-standards.md
+++ b/_pages/law-and-regs/design-standards/1991-design-standards.md
@@ -20,6 +20,7 @@ expand-sidenav: true
 sidenav-pdf:
   title: 1991 ADA Standards for Accessible Design
   filename: 1991-design-standards.pdf
+  text: Download PDF Guidance
 ---
 
 ## 1. Purpose

--- a/_pages/law-and-regs/design-standards/2010-stds.md
+++ b/_pages/law-and-regs/design-standards/2010-stds.md
@@ -21,6 +21,7 @@ expand-sidenav: true
 sidenav-pdf:
   title: 2010 ADA Standards for Accessible Design
   filename: 2010-design-standards.pdf
+  text: Download PDF Guidance
 ---
 ## Introduction
 
@@ -5644,7 +5645,7 @@ To assist in transferring to the bench, consider providing grab bars on a wall a
 
 **903.7 Wet Locations.** Where installed in wet locations, the surface of the seat shall be slip resistant and shall not accumulate water.
 
-### 904 Check-Out Aisles and Sales and Service Counters  
+### 904 Check-Out Aisles and Sales and Service Counters
 
 **904.1 General.** Check-out aisles and sales and service counters shall comply with the applicable requirements of 904.
 

--- a/_pages/law-and-regs/design-standards/standards-guidance.md
+++ b/_pages/law-and-regs/design-standards/standards-guidance.md
@@ -15,6 +15,7 @@ redirect_from:
 sidenav-pdf:
   title: Guidance on the 2010 ADA Standards for Accessible Design
   filename: guidance-2010-standards.pdf
+  text: Download PDF Guidance
 ---
 ## State and Local Government Facilities: Guidance on the Revisions to 28 CFR 35.151
 

--- a/_pages/law-and-regs/title-ii-2010-regulations.md
+++ b/_pages/law-and-regs/title-ii-2010-regulations.md
@@ -19,6 +19,7 @@ redirect_from:
 sidenav-pdf:
   title: Americans with Disabilities Act Title II Regulations
   filename: title-ii-2010-regulations.pdf
+  text: Download PDF
 expand-sidenav: true
 related-content: true
 tags:

--- a/_pages/law-and-regs/title-iii-regulations.md
+++ b/_pages/law-and-regs/title-iii-regulations.md
@@ -13,6 +13,7 @@ redirect_from:
 sidenav-pdf:
   title: Americans with Disabilities Act Title III Regulations
   filename: title-iii-2010-regulations.pdf
+  text: Download PDF
 expand-sidenav: true
 related-content: true
 tags:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -436,6 +436,11 @@ collections:
             name: filename
             widget: string
             required: false
+          - label: Text
+            name: text
+            widget: string
+            required: false
+            default: "Download PDF"
         required: false
       - label: Related Content
         name: related-content
@@ -474,6 +479,23 @@ collections:
         widget: boolean
         default: true
         required: false
+      - label: Sidenav PDF
+        name: sidenav-pdf
+        widget: object
+        fields:
+          - label: Title
+            name: title
+            widget: string
+            required: false
+          - label: Filename
+            name: filename
+            widget: string
+            required: false
+          - label: Text
+            name: text
+            widget: string
+            required: false
+            default: "Download PDF"
       - label: Body Content
         name: body
         widget: markdown
@@ -511,6 +533,23 @@ collections:
         widget: boolean
         default: true
         required: false
+      - label: Sidenav PDF
+        name: sidenav-pdf
+        widget: object
+        fields:
+          - label: Title
+            name: title
+            widget: string
+            required: false
+          - label: Filename
+            name: filename
+            widget: string
+            required: false
+          - label: Text
+            name: text
+            widget: string
+            required: false
+            default: "Download PDF"
       - label: Body Content
         name: body
         widget: markdown


### PR DESCRIPTION
# What does this change?

Re: https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/813#issuecomment-1612991724

- 🌎 Right now the button can only say "Download PDF Guidance"
- ⛔ We want to make buttons for non-guidance downloads
- ✅ This commit enables that, and adds flags to edit it in netlify

# Proof it works

## Laws and Regs:

<img width="1245" alt="image" src="https://github.com/usdoj-crt/beta-ada/assets/15126660/604c759b-4f7f-419e-a7eb-4224b3dad4d0">

## Guidance:

<img width="1236" alt="image" src="https://github.com/usdoj-crt/beta-ada/assets/15126660/1b47b3ef-313e-446f-8711-d704b6b6e9cf">
