### PR TITLE
Remove aria-label from learn more

### DIFF
--- a/_includes/landing/learn.html
+++ b/_includes/landing/learn.html
@@ -35,7 +35,7 @@
                   <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
-                        <a class="text-white learn-link" aria-label="learn more example link" href="{{example.link | relative_url }}">
+                        <a class="text-white learn-link" href="{{example.link | relative_url }}">
                             {{ example.title }}
                         </a>
                     </li>


### PR DESCRIPTION
Make "learn more" links read correctly for screen readers.

- 🌎 These learn more links show up on the landing page. Right now, they have static aria-labels.
- ⛔ This means that they're all read as "learn more example link" to screen readers.
- ✅ This commit removes the aria labels, meaning the link text will be read instead (see example below)

| Before | After |
|--------|--------|
| ![example with reader showing bad aria-label](https://github.com/usdoj-crt/beta-ada/assets/15126660/933aab24-99f1-4d27-9f7c-5f17f065ac90) | ![Example showing reader reading links without label](https://github.com/usdoj-crt/beta-ada/assets/15126660/55552aaa-9358-4fa8-bc85-acbd6c89d725) |


