### PR TITLE
Analytics: Re-add link tracking to the learn more links

### DIFF
--- a/_assets/js/utils/gaUtil.js
+++ b/_assets/js/utils/gaUtil.js
@@ -1,9 +1,15 @@
-function sendGAClickEvent(e) {
-  e.preventDefault();
+function getEventName(e) {
+  if (e.target.dataset.gaEventName) {
+    return e.target.dataset.gaEventName;
+  }
   const ariaLabel = e.target.ariaLabel ?? 'unlabeled link element';
   const innerText = e.target.innerText ?? 'empty link element';
-  const event_name = ariaLabel + ' ' + innerText;
-  gtag('event', 'click', { event_name: event_name });
+  return ariaLabel + ' ' + innerText;
+}
+
+function sendGAClickEvent(e) {
+  e.preventDefault();
+  gtag('event', 'click', { event_name: getEventName(e) });
   window.location.href = e.target.href;
 }
 
@@ -22,7 +28,7 @@ function gtag() {
     ['.best-bet', 'click', sendGAClickEvent],
     ['.expand-all', 'click', sendGAClickEvent],
   ]
-  
+
   export default function initGAEvents() {
     ANALYTICS_CONFIG.forEach(([selector, event, action]) => {
       document.querySelectorAll(selector).forEach(el => {

--- a/_includes/landing/learn.html
+++ b/_includes/landing/learn.html
@@ -35,7 +35,7 @@
                   <ul class="padding-left-2">
                   {% for example in section.examples %}
                     <li class="padding-y-1">
-                        <a class="text-white learn-link" href="{{example.link | relative_url }}">
+                      <a class="text-white learn-link" href="{{example.link | relative_url }}" data-ga-event-name="learn more example link {{example.title}}">
                             {{ example.title }}
                         </a>
                     </li>


### PR DESCRIPTION
- 🌎 The aria-label was used to provide an event name
- ⛔ Aria-label doesn't make sense for all links, and was removed.
- ✅ This commit re-adds an event name without an aria-label