### PR TITLE
Adds external alert configuration.

### DIFF
--- a/_assets/sass/custom/_print.scss
+++ b/_assets/sass/custom/_print.scss
@@ -30,7 +30,7 @@
   #crt-page--sidenav,
   #fba-button,
   .usa-breadcrumb,
-  #warning-banner,
+  .warning-banner,
   #crt-page--expandaccordions--wrapper {
     display: none !important;
   }

--- a/_assets/sass/custom/_site_alert.scss
+++ b/_assets/sass/custom/_site_alert.scss
@@ -6,7 +6,7 @@
 }
 
 // Change the default alert border color and add a small left hand border to the alert
-#warning-banner {
+.warning-banner {
     background-color: #FBF3D1;
 
     .usa-alert__heading {
@@ -19,7 +19,7 @@
 }
 
 // Change the anchor link styling to primary color darker
-#warning-banner a:hover {
+.warning-banner a:hover {
     color: #1a4480;
     text-decoration: underline;
 }

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,18 @@ contact:
   time1: "M, Tu, W, F: 9:30am - 12pm and 3pm - 5:30pm ET"
   time2: "Th: 2:30pm - 5:30pm ET"
 
+# For alerts that aren't tied to a site.categories.notice
+external_notices:
+  - text:
+      en: This is a test
+      es: Esto es una prueba
+    link_text:
+      en: Click here
+      es: Clic aquí
+    link_href:
+      en: https://ada.gov/en
+      es: https://ada.gov/es
+
 # Display beta disclamers
 beta: false
 

--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -20,7 +20,7 @@
 {% endif %}
 
 {% if notice_link || notice_text %}
-<section id="warning-banner" class="usa-site-alert usa-site-alert--info" aria-label='Site alert'>
+<section class="warning-banner usa-site-alert usa-site-alert--info" aria-label='Site alert'>
   <div class="usa-alert">
     <div class="usa-alert__body">
       {% if notice_text %}
@@ -40,4 +40,52 @@
   </div>
 </section>
 {% endif %}
+{% endfor %}
+
+{% for notice in site.external_notices %}
+
+{% if notice.link_text.en==nil && notice.link_text.es==nil %}
+  {% assign link_text = nil %}
+{% elsif lang=="en" %}
+  {% assign link_text = notice.link_text.en %}
+{% elsif lang=="es" %}
+  {% assign link_text = notice.link_text.es %}
+{% endif %}
+
+{% if notice.text.en==nil && notice.text.es==nil %}
+  {% assign text = nil %}
+{% elsif lang=="en" %}
+  {% assign text = notice.text.en %}
+{% elsif lang=="es" %}
+  {% assign text = notice.text.es %}
+{% endif %}
+
+{% if notice.link_href.en==nil && notice.link_href.es==nil %}
+  {% assign link_href = nil %}
+{% elsif lang=="en" %}
+  {% assign link_href = notice.link_href.en %}
+{% elsif lang=="es" %}
+  {% assign link_href = notice.link_href.es %}
+{% endif %}
+
+<section class="warning-banner usa-site-alert usa-site-alert--info" aria-label='Site alert'>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      {% if text %}
+      <h3 class="usa-alert__heading pa11y-skip">{{ text }}</h3>
+      {% endif %}
+      {% if link_text %}
+      <p class="usa-alert__text">
+        <a
+          data-ga-event-name="alert link {{ link_text }}"
+          class="pa11y-skip alert-link"
+          href="{{ link_href | relative_url }}"
+          >{% if lang=="en" %}{{ link_text }}{% elsif lang=="es" %}{{link_text}}{% endif %}</a
+        >
+      </p>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
 {% endfor %}


### PR DESCRIPTION
# What is this?

- 🌎 Our alerts link to notice posts
- ⛔ They _must_ link to notice posts - you can't link to somewhere external.
- ✅ This commit adds a way to add notices via _config.yml, instead

# Proof it works:

![links](https://github.com/usdoj-crt/beta-ada/assets/15126660/1495002d-6176-401f-902d-746d54a7688b)