### PR TITLE
Netlify internal link bug fix

### DIFF
--- a/_assets/js/netlify/makeHTMLFromBodyContent.js
+++ b/_assets/js/netlify/makeHTMLFromBodyContent.js
@@ -5,12 +5,10 @@ md.options['linkify'] = true;
 const parser = new DOMParser();
 function makeHTMLFromBodyContent(bodyContent, variables, imageData) {
   // Replace any <hr> tags with markdown so they render outside of the nearest <p> tag
-  let content = bodyContent
-    ? bodyContent
-      .replaceAll(/<hr>/g, "***")
+  let content = bodyContent?.replaceAll(/<hr>/g, "***")
       .replaceAll("{{'", '')
       .replaceAll("' | relative_url}}", '')
-    : '';
+    || '';
   const contentParts = content.split('{');
   contentParts.forEach(contentPart => {
     if (contentPart.includes('% details')) {

--- a/_assets/js/netlify/makeHTMLFromBodyContent.js
+++ b/_assets/js/netlify/makeHTMLFromBodyContent.js
@@ -5,7 +5,12 @@ md.options['linkify'] = true;
 const parser = new DOMParser();
 function makeHTMLFromBodyContent(bodyContent, variables, imageData) {
   // Replace any <hr> tags with markdown so they render outside of the nearest <p> tag
-  let content = bodyContent ? bodyContent.replaceAll(/<hr>/g, "***") : '';
+  let content = bodyContent
+    ? bodyContent
+      .replaceAll(/<hr>/g, "***")
+      .replaceAll("{{'", '')
+      .replaceAll("' | relative_url}}", '')
+    : '';
   const contentParts = content.split('{');
   contentParts.forEach(contentPart => {
     if (contentPart.includes('% details')) {

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -569,7 +569,7 @@ collections:
   - label: Notices
     name: notices-posts
     summary: "{{title}} ({{filename}})"
-    folder: notices/_posts
+    folder: _pages/notices/_posts
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     fields:

--- a/admin/index.html
+++ b/admin/index.html
@@ -27,8 +27,7 @@ layout: null
       CMS.registerEventListener({
         name: "preSave",
         handler: ({entry}) => {
-          if (entry.get('data').get('collection') === 'law-and-regs') return entry;
-          const body = entry.get("data").get("body").replaceAll(/\\\[/g,"[")
+          const body = entry.get("data").get("body").replaceAll(/\\\[/g,"[").replaceAll(/\\\]/g,"]")
           return entry.get("data").set("body", body);
         }
       });

--- a/admin/index.html
+++ b/admin/index.html
@@ -23,6 +23,14 @@ layout: null
     {% asset dist/netlifyPreview-compiled.js %}
     <script>
       CMS.registerPreviewStyle('{% asset styles.css @path %}');
+      // Fix bug where Netlify adds a backslash to the markdown before internal links
+      CMS.registerEventListener({
+        name: "preSave",
+        handler: ({entry}) => {
+          const body = entry.get("data").get("body").replaceAll(/\\\[/g,"[")
+          return entry.get("data").set("body", body);
+        }
+      });
     </script>
     <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url" />
     <style>

--- a/admin/index.html
+++ b/admin/index.html
@@ -27,6 +27,7 @@ layout: null
       CMS.registerEventListener({
         name: "preSave",
         handler: ({entry}) => {
+          if (entry.get('data').get('collection') === 'law-and-regs') return entry;
           const body = entry.get("data").get("body").replaceAll(/\\\[/g,"[")
           return entry.get("data").set("body", body);
         }


### PR DESCRIPTION
Currently there is a bug where Netlify is adding a \ character in front of links causing them to break. This PR adds JS to remove that character when the entry is saved on Netlify.
It also updates the Netlify config to correctly pull entries under notices.