### PR TITLE
Update sidenav and top nav

### DIFF
--- a/_assets/js/expand-sidenav.js
+++ b/_assets/js/expand-sidenav.js
@@ -3,13 +3,15 @@ const sidenav = () => {
 
     function expandAll(e) {
         const submenuButtons = document.getElementsByClassName('usa-accordion__button');
-        let expandingAll = e.target.innerText === 'Expand all';
+        const innerText = e.target.querySelector('.expand-text').innerText;
+        let expandingAll = innerText === 'Expand all';
         Array.from(submenuButtons).forEach(button => {
             const isExpanded = button.getAttribute('aria-expanded') === "true";
             if (!isExpanded && expandingAll) button.click();
             if (isExpanded && !expandingAll) button.click();
         });
-        e.target.innerText = expandingAll ? 'Collapse all' : 'Expand all';
+        e.target.querySelector('.expand-text').innerText = expandingAll ? 'Collapse all' : 'Expand all';
+        e.target.querySelector('.usa-icon').outerHTML = expandingAll ? '<svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#expand_less"></use></svg>' : '<svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#expand_more"></use></svg>';
     }
 
     if (expandButton) {

--- a/_assets/sass/custom/_buttons.scss
+++ b/_assets/sass/custom/_buttons.scss
@@ -13,7 +13,6 @@
   }
 }
 
-#crt-page--printbutton,
 #crt-page--expandaccordions,
 .crt-page--downloadpdf-button,
 #crt-back-to-top-button {

--- a/_assets/sass/custom/_sidenav.scss
+++ b/_assets/sass/custom/_sidenav.scss
@@ -13,6 +13,12 @@
     flex-direction: column;
   }
 
+  .usa-sidenav__item {
+    .display-flex {
+      display: flex;
+    }
+  }
+
   a:not(.crt-page--downloadpdf-button)  {
     color: color($theme-text-color);
 

--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,27 @@ primary_navigation:
     url:
       en: "/law-and-regs/"
       es: "/law-and-regs/"
+    children:
+      - name:
+          en: ADA
+          en-short: ADA
+          es: ADA
+        url: "/law-and-regs/ada/"
+      - name:
+          en: Title II 2010 Regulations
+          en-short: Title II
+          es: Title II 2010 Regulations
+        url: "/law-and-regs/title-ii-2010-regulations/"
+      - name:
+          en: Title III Regulations
+          en-short: Title III
+          es: Title III Regulations
+        url: "/law-and-regs/title-iii-regulations/"
+      - name:
+          en: Design Standards
+          en-short: Design Standards
+          es: Design Standards
+        url: "/law-and-regs/design-standards/"
   - name:
       en: Enforcement
       en-short: Enforcement

--- a/_includes/download-pdf.html
+++ b/_includes/download-pdf.html
@@ -1,8 +1,11 @@
-<div class="mobile:margin-bottom-4 margin-bottom-2 width-card" markdown="0">
+<li class="usa-sidenav__item" markdown="0">
   <a
+    class="display-flex flex-align-center flex-row flex-justify"
     href="/assets/_pdfs/{{include.filename}}"
-    download
-    class="usa-button crt-page--downloadpdf-button text-bold"
-    >{% if include.text %}{{include.text}}{% else %}Download PDF{% endif %}</a
-  >
-</div>
+    download>
+    <span>{% if include.text %}{{include.text}}{% else %}Download PDF{% endif %}</span>
+    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <use xlink:href="/assets/img/sprite.svg#file_download"></use>
+    </svg>
+  </a>
+</li>

--- a/_includes/expand-button.html
+++ b/_includes/expand-button.html
@@ -1,1 +1,8 @@
-<button style="width: max-content" class="usa-button desktop:margin-bottom-neg-1 mobile:margin-bottom-2 desktop:margin-top-3 bg-primary-darker expand-all" id="expand-all" aria-label="expand all submenus">Expand all</button>
+<li class="usa-sidenav__item">
+    <a href="#" class="expand-all display-flex flex-align-center flex-row flex-justify" id="expand-all" aria-label="expand all submenus">
+        <span class="expand-text">Expand all</span>
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+            <use xlink:href="/assets/img/sprite.svg#expand_more"></use>
+        </svg>
+    </a>
+</li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,9 +38,10 @@
             <ul id="{{ nav_id }}" class="usa-nav__submenu">
               {% for subnav_item in nav_item.children %}
               <li class="usa-nav__submenu-item">
-                <a href="{{ subnav_item.url | prepend: site.baseurl }}"
-                  >{{ subnav_item.name[lang] | escape }}</a
-                >
+                <a href="{{ subnav_item.url | prepend: site.baseurl }}">
+                  <span class="desktop:display-none widescreen:display-block">{{ subnav_item.name["en"] | escape }}</span>
+                  <span class="mobile:display-none desktop:display-block widescreen:display-none">{{ subnav_item.name["en-short"] | escape }}</span>
+                </a>
               </li>
               {% endfor %}
             </ul>

--- a/_includes/print-button.html
+++ b/_includes/print-button.html
@@ -1,3 +1,8 @@
-<div id="crt-page--printbutton--wrapper" class="desktop:margin-top-3 margin-bottom-2 width-card">
-  <button id="crt-page--printbutton" class="usa-button">Print this page</button>
-</div>
+<li class="usa-sidenav__item">
+  <a href="#" id="crt-page--printbutton" class="display-flex flex-align-center flex-row flex-justify" aria-label="expand all submenus">
+    <span>Print this page</span>
+    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <use xlink:href="/assets/img/sprite.svg#print"></use>
+    </svg>
+  </a>
+</li>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -6,10 +6,20 @@
   aria-label="{{site.data[lang]['i18n'].aria.side_nav}}"
 >
 <ul class="usa-sidenav">
+    {% if page.print %}
+      {% include print-button.html %}
+    {% endif %}
+    {% if page.sidenav-pdf.title and page.sidenav-pdf.filename %}
+      {% include download-pdf.html text=page.sidenav-pdf.text filename=page.sidenav-pdf.filename %}
+    {% endif %}
+    {% if page.expand-sidenav %}
+      {% include expand-button.html %}
+    {% endif %}
   <li class="usa-sidenav__item">
-    <a href="#top" class="usa-current"
-      >{% if page.short_title %}{{ page.short_title }}{% else %}{{ page.title }}{% endif %}</a
-    ></li>
+    <a href="#top" class="usa-current">
+      {% if page.short_title %}{{ page.short_title }}{% else %}{{ page.title }}{% endif %}
+    </a>
+  </li>
     {% include subnav.html collection = page.subnav level=0 %}
   </ul>
 </nav>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,15 +23,6 @@ layout: default
       {% include sidenav.html collection=page.subnav %}
       </div>
       {% endif %}
-      {% if page.expand-sidenav %}
-        {% include expand-button.html %}
-      {% endif %}
-      {% if page.print %}
-        {% include print-button.html %}
-      {% endif %}
-      {% if page.sidenav-pdf.title and page.sidenav-pdf.filename %}
-        {% include download-pdf.html text=page.sidenav-pdf.text filename=page.sidenav-pdf.filename %}
-      {% endif %}
     </div>
     {% endif %}
     <div


### PR DESCRIPTION
This PR moves the print, download, and expand buttons to the top of the sidenav and adds the ADA, Title II, Title III, and Design Standards to the top nav:

![image](https://github.com/usdoj-crt/beta-ada/assets/18104884/42583286-a082-4bcd-ba13-a8c5d21e3dfd)

![image](https://github.com/usdoj-crt/beta-ada/assets/18104884/093f53b2-4dba-464a-80a3-862c134de406)
