### PR TITLE
Add feature flag and a/b testing

### DIFF
--- a/_assets/js/feature-flag.js
+++ b/_assets/js/feature-flag.js
@@ -1,38 +1,39 @@
-export default function getCookies() {
+export default function setCookies() {
     const isNetlifyUser = sessionStorage.getItem('isNetlifyUser') ?? false;
-    const featureFlags = setFeatureFlagCookies(isNetlifyUser);
-    const variant = setVariant();
-
-    return {'variant': variant, 'feature_flags': featureFlags};
+    setFeatureFlagCookies(isNetlifyUser);
   }
 
-function setVariant() {
+function setPublicPercentVariant(name, publicPercentOn) {
   let variant;
   // Check if the user already has a variant assigned
   const userVariant = document.cookie
       .split("; ")
-      .find((row) => row.startsWith("ab_variant="))
+      .find((row) => row.startsWith(name + "="))
       ?.split("=")[1];
 
   if (userVariant) {
     variant = userVariant;
   } else {
     // Assign a random variant if the user doesn't have one
-    variant = Math.random() < 0.5 ? 'A' : 'B';
-    // Set the variant in a cookie for future visits
-    document.cookie = 'ab_variant='+ variant;
+    variant = Math.random() < publicPercentOn ? true : false;
   }
 
   return variant;
 }
 
 const FEATURE_FLAGS = [
-    'laws-and-regs',
+    {
+      name: 'laws-and-regs',
+      released: false,
+      publicPercentOn: 0,
+      optedIn: false,
+    }
 ];
 
 function setFeatureFlagCookies(allowlisted=false) {
-    return FEATURE_FLAGS.filter((flag) => {
-      document.cookie = flag + '=' + allowlisted;
-      return allowlisted;
+    FEATURE_FLAGS.forEach((flag) => {
+      const publicPercentVariant = setPublicPercentVariant(flag.name, flag.publicPercentOn);
+      flag.optedIn = allowlisted;
+      document.cookie = flag.name + '=' + (publicPercentVariant || flag.optedIn || flag.released);
     });
 }

--- a/_assets/js/feature-flag.js
+++ b/_assets/js/feature-flag.js
@@ -1,0 +1,38 @@
+export default function getCookies() {
+    const isNetlifyUser = sessionStorage.getItem('isNetlifyUser') ?? false;
+    const featureFlags = setFeatureFlagCookies(isNetlifyUser);
+    const variant = setVariant();
+
+    return {'variant': variant, 'feature_flags': featureFlags};
+  }
+
+function setVariant() {
+  let variant;
+  // Check if the user already has a variant assigned
+  const userVariant = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("ab_variant="))
+      ?.split("=")[1];
+
+  if (userVariant) {
+    variant = userVariant;
+  } else {
+    // Assign a random variant if the user doesn't have one
+    variant = Math.random() < 0.5 ? 'A' : 'B';
+    // Set the variant in a cookie for future visits
+    document.cookie = 'ab_variant='+ variant;
+  }
+
+  return variant;
+}
+
+const FEATURE_FLAGS = [
+    'laws-and-regs',
+];
+
+function setFeatureFlagCookies(allowlisted=false) {
+    return FEATURE_FLAGS.filter((flag) => {
+      document.cookie = flag + '=' + allowlisted;
+      return allowlisted;
+    });
+}

--- a/_assets/js/feature-flag.js
+++ b/_assets/js/feature-flag.js
@@ -4,21 +4,16 @@ export default function setCookies() {
   }
 
 function setPublicPercentVariant(name, publicPercentOn) {
-  let variant;
   // Check if the user already has a variant assigned
   const userVariant = document.cookie
       .split("; ")
       .find((row) => row.startsWith(name + "="))
       ?.split("=")[1];
 
-  if (userVariant) {
-    variant = userVariant;
-  } else {
-    // Assign a random variant if the user doesn't have one
-    variant = Math.random() < publicPercentOn ? true : false;
-  }
+  if (userVariant) return userVariant;
 
-  return variant;
+  // Assign a random variant if the user doesn't have one
+  return Math.random() < publicPercentOn;
 }
 
 const FEATURE_FLAGS = [
@@ -30,7 +25,7 @@ const FEATURE_FLAGS = [
     }
 ];
 
-function setFeatureFlagCookies(allowlisted=false) {
+function setFeatureFlagCookies(allowlisted) {
     FEATURE_FLAGS.forEach((flag) => {
       const publicPercentVariant = setPublicPercentVariant(flag.name, flag.publicPercentOn);
       flag.optedIn = allowlisted;

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -15,10 +15,10 @@ redirectModal();
 print();
 printButton();
 search();
-initGAEvents();
 sidenav();
 mobileCarousel();
 setCookies();
+initGAEvents();
 
 const lawsAndRegsFlag = document.cookie
   .split("; ")

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -8,7 +8,7 @@ import print from "./print";
 import search from "./search";
 import sidenav from "./expand-sidenav";
 import mobileCarousel from "./carousel";
-import getCookies from "./feature-flag";
+import setCookies from "./feature-flag";
 
 modal();
 redirectModal();
@@ -18,9 +18,14 @@ search();
 initGAEvents();
 sidenav();
 mobileCarousel();
+setCookies();
 
-const cookies = getCookies();
-if (cookies.feature_flags.includes('laws-and-regs')) {
+const lawsAndRegsFlag = document.cookie
+  .split("; ")
+  .find((row) => row.startsWith("laws-and-regs="))
+  ?.split("=")[1];
+
+if (lawsAndRegsFlag === 'true') {
   // call laws and regs parsing function here
   console.log('allowlisted on laws-and-regs feature flag');
 }

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -8,6 +8,7 @@ import print from "./print";
 import search from "./search";
 import sidenav from "./expand-sidenav";
 import mobileCarousel from "./carousel";
+import getCookies from "./feature-flag";
 
 modal();
 redirectModal();
@@ -17,6 +18,12 @@ search();
 initGAEvents();
 sidenav();
 mobileCarousel();
+
+const cookies = getCookies();
+if (cookies.feature_flags.includes('laws-and-regs')) {
+  // call laws and regs parsing function here
+  console.log('allowlisted on laws-and-regs feature flag');
+}
 
 const anchors = new AnchorJS();
 anchors.add(".crt-page h2:not([class*='usa']) h2:not(.noAnchor)");

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -16,6 +16,10 @@ const preview = createClass({
 
 await loadSiteData();
 
+window.addEventListener('popstate', () => {
+  if (document.querySelector('nav')) sessionStorage.setItem('isNetlifyUser', true);
+});
+
 const pages = [
   'index',
   'topics',

--- a/_assets/js/utils/gaUtil.js
+++ b/_assets/js/utils/gaUtil.js
@@ -9,11 +9,7 @@ function getEventName(e) {
 
 function sendGAClickEvent(e) {
   e.preventDefault();
-  const userVariant = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("ab_variant="))
-    ?.split("=")[1];
-  gtag('event', 'click', { event_name: getEventName(e), user_variant: userVariant });
+  gtag('event', 'click', { event_name: getEventName(e) });
   if (!e.target.href) return;
   window.location.href = e.target.href;
 }

--- a/_assets/js/utils/gaUtil.js
+++ b/_assets/js/utils/gaUtil.js
@@ -9,7 +9,11 @@ function getEventName(e) {
 
 function sendGAClickEvent(e) {
   e.preventDefault();
-  gtag('event', 'click', { event_name: getEventName(e) });
+  const userVariant = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("ab_variant="))
+    ?.split("=")[1];
+  gtag('event', 'click', { event_name: getEventName(e), user_variant: userVariant });
   if (!e.target.href) return;
   window.location.href = e.target.href;
 }


### PR DESCRIPTION
This PR enables feature flags to show features only to users who have logged into Netlify by adding a session variable. It also adds A/B testing capabilities by randomly assigning cookie A to 50% of users and cookie B to the other 50%.