### PR TITLE
Add checkbox to admin page for feature flags

### DIFF
--- a/_assets/js/feature-flag.js
+++ b/_assets/js/feature-flag.js
@@ -1,8 +1,3 @@
-export default function setCookies() {
-    const isNetlifyUser = sessionStorage.getItem('isNetlifyUser') ?? false;
-    setFeatureFlagCookies(isNetlifyUser);
-  }
-
 function setPublicPercentVariant(name, publicPercentOn) {
   // Check if the user already has a variant assigned
   const userVariant = document.cookie
@@ -25,11 +20,12 @@ const FEATURE_FLAGS = [
     }
 ];
 
-function setFeatureFlagCookies(allowlisted) {
+export default function setCookies() {
     FEATURE_FLAGS.forEach((flag) => {
       const publicPercentVariant = setPublicPercentVariant(flag.name, flag.publicPercentOn);
-      flag.optedIn = allowlisted;
+      flag.optedIn = sessionStorage.getItem(flag.name) ?? false;
       document.cookie = flag.name + '=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+      if (flag.optedIn === 'false') return;
       if (publicPercentVariant || flag.optedIn || flag.released) document.cookie = flag.name + '=true';
     });
 }

--- a/_assets/js/netlify/preview.js
+++ b/_assets/js/netlify/preview.js
@@ -16,10 +16,6 @@ const preview = createClass({
 
 await loadSiteData();
 
-window.addEventListener('popstate', () => {
-  if (document.querySelector('nav')) sessionStorage.setItem('isNetlifyUser', true);
-});
-
 const pages = [
   'index',
   'topics',

--- a/admin/index.html
+++ b/admin/index.html
@@ -31,6 +31,35 @@ layout: null
           return entry.get("data").set("body", body);
         }
       });
+
+      const FEATURE_FLAGS = ['laws-and-regs'];
+
+      const contentContainer = document.querySelector('#nc-root');
+
+      const observer = new MutationObserver(function(mutations) {
+        FEATURE_FLAGS.forEach((flag) => {
+          if (sessionStorage.getItem(flag) === 'true') {
+            const flagCheckBox = document.getElementById(flag);
+            flagCheckBox.checked = true;
+          }
+        });
+        mutations.forEach(function(mutation) {
+          const header = Array.from(contentContainer.childNodes).filter((node) => node.localName === 'header');
+          const featureFlagMenu = document.getElementById('featureFlag');
+          if (header.length) {
+            featureFlagMenu.style.display = 'block';
+          } else {
+            featureFlagMenu.style.display = 'none';
+          }
+        });
+      });
+
+      observer.observe(contentContainer, { childList: true });
+
+      function setFlag(checkbox, flagName) {
+        sessionStorage.setItem(flagName, checkbox.checked);
+      }
+
     </script>
     <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url" />
     <style>
@@ -53,7 +82,26 @@ layout: null
       .css-pp9jk1-DropdownList-dropdownList-DropdownList .css-1hu7ve8-button-dropdownItem-StyledMenuItem {
         color: #6C7584;
       }
+      .feature-flag-wrapper {
+        background-color: white;
+        padding: 16px 12px;
+        border-radius: 5px;
+        width: 250px;
+        box-shadow: rgba(68, 74, 87, 0.05) 0px 2px 6px 0px, rgba(68, 74, 87, 0.1) 0px 1px 3px 0px;
+        margin-left: 18px;
+        position: absolute;
+        top: 605px;
+        z-index: -1;
+      }
+      .checkbox-label {
+        font-size: 14px;
+      }
     </style>
-
+    <div class="feature-flag-wrapper" id="featureFlag" style="display: none;">
+      <h2>Feature flags</h2>
+      <input id="laws-and-regs" type="checkbox" onclick="setFlag(this, 'laws-and-regs')">
+        <label class="checkbox-label">Law and regs</label>
+      </input>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
This PR updates the logic for the feature flag to use a checkbox selection rather than a window event listener. Checking the box will allowlist the Netlify user on the feature and unchecking it will blocklist them. Once the session expires the user will blocklisted until they check the box again.

![image](https://github.com/usdoj-crt/beta-ada/assets/18104884/8a39a467-6871-41e1-9277-8ffd30c25777)
