### PR TITLE
Highlight law and reg text

### DIFF
--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -88,13 +88,27 @@ function buildBtns(i, divType) {
         } else if (btnType === 'Copy') {
             btn.innerHTML = '<span class="copied text-no-underline" style="display:none;">Copied text</span><svg ' + gaEventName + ' class="usa-icon copy-icon usa-tooltip" data-position="bottom" title="Copy text" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#content_copy"></use></svg>';
             btn.addEventListener('click', (e) => { copyText(e, divType) });
+            btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
+            btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });
         } else if (btnType === 'Print') {
             btn.innerHTML = '<svg ' + gaEventName + ' class="usa-icon usa-tooltip" data-position="bottom" title="Print" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#print"></use></svg>';
             btn.addEventListener('click', (e) => { printText(e, divType) });
+            btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
+            btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });
         }
         btnDiv.appendChild(btn);
     });
     return btnDiv;
+}
+
+function highlightText(e, divType) {
+    const section = e.target.closest(divType);
+    section.className = 'section highlight';
+}
+
+function unHighlightText(e, divType) {
+    const section = e.target.closest(divType);
+    section.className = 'section';
 }
 
 function copyText(e, divType) {

--- a/_assets/sass/custom/_page.scss
+++ b/_assets/sass/custom/_page.scss
@@ -36,6 +36,10 @@
   .section {
     position: relative;
 
+    &.highlight {
+      background-color: #FDFD96;
+    }
+
     .btn-group {
       display: flex;
       gap: 8px;

--- a/_pages/_resources/telehealth-guidance.md
+++ b/_pages/_resources/telehealth-guidance.md
@@ -1,12 +1,11 @@
 ---
 title: "Guidance on Nondiscrimination in Telehealth: Federal Protections to Ensure Accessibility to People with Disabilities and Limited English Proficient Persons"
-description: "This guidance explains how various federal laws require making telehealth accessible to people
-with disabilities and limited English proficient persons."
+description: "This guidance explains how various federal laws require making telehealth accessible to people with disabilities and limited English proficient persons."
 permalink: /resources/telehealth-guidance/
 redirect_from:
   - /telehealth_guidance.pdf/
 lead: |-
-  
+
 lang: "en"
 news-item: false
 publish-date: 2022-05-12 00:00:00
@@ -312,7 +311,7 @@ health emergency (March 20, 2020), *available at* [https://www.hhs.gov/sites/def
 {% fnbody 10 %}
 U.S. Dep’t of Health and Hum. Servs., Guidance on How the HIPAA Rules Permit Covered Health Care
 Providers and Health Plans to Use Remote Communication Technologies for Audio-Only Telehealth (Jun. 13,
-2022), *available at* [https://www.hhs.gov/about/news/2022/06/13/hhs-issues-guidance-hipaa-audio-telehealth.html](https://www.hhs.gov/about/news/2022/06/13/hhs-issues-guidance-hipaa-audio-telehealth.html). 
+2022), *available at* [https://www.hhs.gov/about/news/2022/06/13/hhs-issues-guidance-hipaa-audio-telehealth.html](https://www.hhs.gov/about/news/2022/06/13/hhs-issues-guidance-hipaa-audio-telehealth.html).
 {% endfnbody %}
 {% fnbody 11 %}
 U.S. Dep’t of Health and Hum. Servs. Off. for Civ. Rts., HHS.gov, *available at* [https://www.hhs.gov/civilrights/index.html](https://www.hhs.gov/civilrights/index.html) (last visited Jun. 21, 2022).

--- a/_pages/law-and-regs/design-standards/2010-stds.md
+++ b/_pages/law-and-regs/design-standards/2010-stds.md
@@ -12,7 +12,6 @@ redirect_from:
 print: true
 interactive-headers: true
 lang: en
-interactive-headers: true
 sidenav-pdf:
   title: 2010 ADA Standards for Accessible Design
   filename: 2010-design-standards.pdf
@@ -21,19 +20,8 @@ subnavigation: true
 title: 2010 ADA Standards for Accessible Design
 related-content: true
 expand-sidenav: true
-lead: The  Department of Justice published revised regulations for Titles II and
-  III of  the Americans with Disabilities Act of 1990 ADA in the <em>Federal
-  Register</em> on September 15, 2010. These  regulations adopted revised,
-  enforceable accessibility standards called the  2010 ADA Standards for
-  Accessible Design 2010 Standards or Standards.  The 2010 Standards set minimum
-  requirements – both scoping and technical -- for newly designed and
-  constructed or altered State and local government facilities, public
-  accommodations, and commercial facilities to be readily accessible to and
-  usable by individuals with disabilities.
-description: The 2010 Standards set minimum requirements – both scoping and
-  technical -- for newly designed and constructed or altered State and local
-  government facilities, public accommodations, and commercial facilities to be
-  readily accessible to and usable by individuals with disabilities.
+lead: The  Department of Justice published revised regulations for Titles II and III of  the Americans with Disabilities Act of 1990 ADA in the <em>Federal Register</em> on September 15, 2010. These  regulations adopted revised, enforceable accessibility standards called the  2010 ADA Standards for Accessible Design 2010 Standards or Standards.  The 2010 Standards set minimum requirements – both scoping and technical -- for newly designed and constructed or altered State and local government facilities, public accommodations, and commercial facilities to be readily accessible to and usable by individuals with disabilities.
+description: The 2010 Standards set minimum requirements – both scoping and technical -- for newly designed and constructed or altered State and local government facilities, public accommodations, and commercial facilities to be readily accessible to and usable by individuals with disabilities.
 ---
 ## Introduction
 


### PR DESCRIPTION
This PR adds a script to highlight the relevant section when the copy or print button is hovered over in the laws and regs so users know which portion of the text they are copying. It also fixes some page field issues to fix Netlify rendering.

![image](https://github.com/usdoj-crt/beta-ada/assets/18104884/8d7f8369-cb25-492b-bdbd-7abbeb84f018)



