### PR TITLE
Update copy and print for law and regs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -59,8 +59,9 @@ jobs:
       ################################
       - name: Lint Code Base
         uses: github/super-linter@v4.0.2
-        rules:
-          MD024: false
+        with:
+          rules:
+            MD024: false
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_INCLUDE: .*(\_assets|\_pages|\_site).*

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -59,9 +59,6 @@ jobs:
       ################################
       - name: Lint Code Base
         uses: github/super-linter@v4.0.2
-        with:
-          rules:
-            MD024: false
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_INCLUDE: .*(\_assets|\_pages|\_site).*

--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -26,6 +26,7 @@ MD026: false
 MD029: false                  # Ordered list item prefix
 MD033: false                  # Allow inline HTML
 MD036: false                  # Emphasis used instead of a heading
+MD024: false                  # Duplicate headings
 
 #################
 # Rules by tags #

--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -81,7 +81,7 @@ function buildBtns(i, divType) {
     const btnDiv = createDiv('btn-group display-flex flex-row flex-justify maxw-card');
     const btnTypes = ['Share', 'Copy', 'Print'];
     btnTypes.forEach(btnType => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('a');
         btn.className = btnType + '-btn text-no-underline section-btn';
         const gaEventName = 'data-ga-event-name="' + btnType + ' ' + divType + ' ' + i + '"';
         btn.setAttribute('aria-label', btnType);

--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -157,13 +157,13 @@ function unHighlightText(e, divType) {
 }
 
 function openAccordions(section) {
-    Array.from(section.getElementsByTagName('details')).forEach(accordion => {
+    section.querySelectorAll('details').forEach(accordion => {
         accordion.setAttribute('open', true);
     });
 }
 
 function closeAccordions(section) {
-    Array.from(section.getElementsByTagName('details')).forEach(accordion => {
+    section.querySelectorAll('details').forEach(accordion => {
         accordion.removeAttribute('open');
     });
 }

--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -85,6 +85,7 @@ function buildBtns(i, divType) {
         btn.className = btnType + '-btn text-no-underline section-btn';
         const gaEventName = 'data-ga-event-name="' + btnType + ' ' + divType + ' ' + i + '"';
         btn.setAttribute('aria-label', btnType);
+        btn.href = '#';
         if (btnType === 'Share') {
             btn.innerHTML = '<span class="copied-link text-no-underline" style="display:none;">Copied link</span><svg title="Copy link" ' + gaEventName + ' class="usa-icon share-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Copy link</title><use xlink:href="/assets/img/sprite.svg#link"></use></svg>';
             btn.addEventListener('click', (e) => { shareLink(e, divType) });

--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -3,6 +3,10 @@ export default function parseLawsAndRegs (mainContent) {
     if (location.includes('SVGAnimatedString')) {
         history.back();
     }
+    if (location.includes('SVGAnimatedString')) {
+        setTimeout(() => parseLawsAndRegs(mainContent), 500);
+        return;
+    }
     if (!mainContent) return;
 
     const parent = mainContent.parentElement;
@@ -87,15 +91,52 @@ function buildBtns(i, divType) {
         btn.setAttribute('aria-label', btnType);
         btn.href = '#';
         if (btnType === 'Share') {
-            btn.innerHTML = '<span class="copied-link text-no-underline" style="display:none;">Copied link</span><svg title="Copy link" ' + gaEventName + ' class="usa-icon share-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Copy link</title><use xlink:href="/assets/img/sprite.svg#link"></use></svg>';
+            btn.innerHTML = `
+                <span class="copied-link text-no-underline" style="display:none;">Copied link</span>
+                <svg title="Copy link"
+                    ${gaEventName}
+                    class="usa-icon share-icon usa-tooltip"
+                    data-position="bottom"
+                    focusable="false"
+                    role="img">
+                    <title>Copy link</title>
+                    <use xlink:href="/assets/img/sprite.svg#link"></use>
+                </svg>
+            `;
             btn.addEventListener('click', (e) => { shareLink(e, divType) });
         } else if (btnType === 'Copy') {
-            btn.innerHTML = '<span class="copied text-no-underline" style="display:none;">Copied text</span><svg title="Copy text" ' + gaEventName + ' class="usa-icon copy-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Copy text</title><use xlink:href="/assets/img/sprite.svg#content_copy"></use></svg>';
+            btn.innerHTML = `
+                <span class="copied text-no-underline" style="display:none;">
+                    Copied text
+                </span>
+                <svg
+                    title="Copy text"
+                    ${gaEventName}
+                    class="usa-icon copy-icon usa-tooltip"
+                    data-position="bottom"
+                    focusable="false"
+                    role="img">
+                    <title>Copy text</title>
+                    <use xlink:href="/assets/img/sprite.svg#content_copy">
+                    </use>
+                </svg>
+            `;
             btn.addEventListener('click', (e) => { copyText(e, divType) });
             btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
             btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });
         } else if (btnType === 'Print') {
-            btn.innerHTML = '<svg title="Print" ' + gaEventName + ' class="usa-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Print</title><use xlink:href="/assets/img/sprite.svg#print"></use></svg>';
+            btn.innerHTML = `
+                <svg
+                    title="Print"
+                    ${gaEventName}
+                    class="usa-icon usa-tooltip"
+                    data-position="bottom"
+                    focusable="false" role="img">
+                    <title>Print</title>
+                    <use xlink:href="/assets/img/sprite.svg#print">
+                    </use>
+                </svg>
+            `;
             btn.addEventListener('click', (e) => { printText(e, divType) });
             btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
             btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });

--- a/_assets/js/laws-regs-parser.js
+++ b/_assets/js/laws-regs-parser.js
@@ -1,4 +1,8 @@
 export default function parseLawsAndRegs (mainContent) {
+    const location = window.location.href;
+    if (location.includes('SVGAnimatedString')) {
+        history.back();
+    }
     if (!mainContent) return;
 
     const parent = mainContent.parentElement;
@@ -77,21 +81,20 @@ function buildBtns(i, divType) {
     const btnDiv = createDiv('btn-group display-flex flex-row flex-justify maxw-card');
     const btnTypes = ['Share', 'Copy', 'Print'];
     btnTypes.forEach(btnType => {
-        const btn = document.createElement('a');
+        const btn = document.createElement('div');
         btn.className = btnType + '-btn text-no-underline section-btn';
         const gaEventName = 'data-ga-event-name="' + btnType + ' ' + divType + ' ' + i + '"';
         btn.setAttribute('aria-label', btnType);
-        btn.href = '#';
         if (btnType === 'Share') {
-            btn.innerHTML = '<span class="copied-link text-no-underline" style="display:none;">Copied link</span><svg ' + gaEventName + ' class="usa-icon share-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>copy link</title><use xlink:href="/assets/img/sprite.svg#link"></use></svg>';
+            btn.innerHTML = '<span class="copied-link text-no-underline" style="display:none;">Copied link</span><svg title="Copy link" ' + gaEventName + ' class="usa-icon share-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Copy link</title><use xlink:href="/assets/img/sprite.svg#link"></use></svg>';
             btn.addEventListener('click', (e) => { shareLink(e, divType) });
         } else if (btnType === 'Copy') {
-            btn.innerHTML = '<span class="copied text-no-underline" style="display:none;">Copied text</span><svg ' + gaEventName + ' class="usa-icon copy-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>copy text</title><use xlink:href="/assets/img/sprite.svg#content_copy"></use></svg>';
+            btn.innerHTML = '<span class="copied text-no-underline" style="display:none;">Copied text</span><svg title="Copy text" ' + gaEventName + ' class="usa-icon copy-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Copy text</title><use xlink:href="/assets/img/sprite.svg#content_copy"></use></svg>';
             btn.addEventListener('click', (e) => { copyText(e, divType) });
             btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
             btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });
         } else if (btnType === 'Print') {
-            btn.innerHTML = '<svg title="print" ' + gaEventName + ' class="usa-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>print</title><use xlink:href="/assets/img/sprite.svg#print"></use></svg>';
+            btn.innerHTML = '<svg title="Print" ' + gaEventName + ' class="usa-icon usa-tooltip" data-position="bottom" focusable="false" role="img"><title>Print</title><use xlink:href="/assets/img/sprite.svg#print"></use></svg>';
             btn.addEventListener('click', (e) => { printText(e, divType) });
             btn.addEventListener('mouseover', (e) => { highlightText(e, divType) });
             btn.addEventListener('mouseleave', (e) => { unHighlightText(e, divType) });
@@ -111,9 +114,22 @@ function unHighlightText(e, divType) {
     section.classList.remove('highlight');
 }
 
+function openAccordions(section) {
+    Array.from(section.getElementsByTagName('details')).forEach(accordion => {
+        accordion.setAttribute('open', true);
+    });
+}
+
+function closeAccordions(section) {
+    Array.from(section.getElementsByTagName('details')).forEach(accordion => {
+        accordion.removeAttribute('open');
+    });
+}
+
 function copyText(e, divType) {
     e.preventDefault();
     const section = e.target.closest(divType);
+    openAccordions(section);
     const selection = window.getSelection();
     const range = document.createRange();
     range.selectNodeContents(section);
@@ -122,6 +138,7 @@ function copyText(e, divType) {
     // using deprecated execCommand function to maintain formatting lost when using navigate
     document.execCommand('copy');
     window.getSelection().removeAllRanges();
+    closeAccordions(section);
     const copyText = section.getElementsByClassName('copied')[0];
     const copyIcon = section.getElementsByClassName('copy-icon')[0];
     copyText.style.display = 'block';
@@ -135,6 +152,7 @@ function copyText(e, divType) {
 function printText(e, divType) {
     e.preventDefault();
     const section = e.target.closest(divType);
+    openAccordions(section);
     const winPrint = window.open('', '', 'left=0,top=0,width=800,height=900,toolbar=0,scrollbars=0,status=0');
     winPrint.document.write(section.outerHTML);
     Array.from(winPrint.document.getElementsByClassName('btn-group')).forEach(btnGroup => btnGroup.style.display = 'none');

--- a/_pages/_resources/access-911.md
+++ b/_pages/_resources/access-911.md
@@ -104,7 +104,7 @@ Historically, many persons who use TTYs have not had confidence in the accessibi
 {% details Q: If a PSAP complies with a State law, which requires only one TTY per PSAP, is that PSAP also in compliance with the ADA? %}
 A: No. Satisfying State law requirements does not mean that a PSAP is also in compliance with the ADA. Some State laws require only one TTY per PSAP. The ADA, however, requires direct, equal access, which means that PSAPs must have enough TTY equipment so that each call-taking position has its own TTY capability. Also, if a PSAP has extra voice telephone equipment in case of malfunction, which most do, the ADA would also require them to have back-up TTY equipment. Therefore, under the ADA, virtually all PSAPs must have two or more TTYs.
 {% enddetails %}
- 
+
 #### Enhanced Features
 
 Many PSAPs have advanced features that facilitate prompt responses to callers. Many PSAPs have, for example, automatic number identification (ANI) and automatic location identification (ALI), which tell the call taker the phone number and address from which a call originates. PSAPs that have these features must ensure that TTY calls have the same access to enhanced features as do voice telephone calls. TTY calls may not be required to be transferred to a third line, because those transfers often result in the loss of the automatic phone number and address information. Another feature employed by PSAPs is automatic call distribution (ACD), which places incoming calls into a queue, sends out a programmed message to callers to let them know that their calls have been received, and distributes calls to the next available call taker. This feature, if offered, must also be made accessible for TTY calls, with a programmed TTY message.

--- a/_pages/law-and-regs/design-standards/1991-design-standards.md
+++ b/_pages/law-and-regs/design-standards/1991-design-standards.md
@@ -1,6 +1,6 @@
 ---
 title: ADA Standards for Accessible Design Title III Regulation 28 CFR Part 36 (1991)
-description: TBD
+description: The 1991 Design Standards set accessibility requirements for newly constructed or altered government and commercial facilities and public accommodations.
 permalink: /law-and-regs/design-standards/1991-design-standards/
 lead: |-
   Editor's Note:


### PR DESCRIPTION
This PR fixes two issues with the law and regs copy/print functionality:
1. Resolves a bug where the user was directed to a 404 page after printing
2. Opens accordions when copying and printing so all content within the accordions is captured.