### PR TITLE
Patch Conflicting Tooltips

### DIFF
--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -72,7 +72,7 @@ function expandPanel(hash) {
 // USWDS generates tooltips with duplicate ids. This finds and re-ids them.
 window.addEventListener("DOMContentLoaded", function() {
   const ids = new Set();
-  document.querySelectorAll("usa-tooltip__body").forEach(tooltip => {
+  document.querySelectorAll(".usa-tooltip__body").forEach(tooltip => {
     let conflicted = false;
     const describedby = `[aria-describedby="${tooltip.id}"]`;
     while (ids.has(tooltip.id)) {

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -67,3 +67,24 @@ function expandPanel(hash) {
     button.click();
   }
 }
+
+// Hacky fix for https://github.com/uswds/uswds/issues/4338
+// USWDS generates tooltips with duplicate ids. This finds and re-ids them.
+window.addEventListener("DOMContentLoaded", function() {
+  const ids = new Set();
+  document.querySelectorAll("usa-tooltip__body").forEach(tooltip => {
+    let conflicted = false;
+    const describedby = `[aria-describedby="${tooltip.id}"]`;
+    while (ids.has(tooltip.id)) {
+      conflicted = true;
+      tooltip.id += "a";
+    }
+    ids.add(tooltip.id);
+
+    if (!conflicted) return;
+
+    document.querySelectorAll(describedby).forEach(el => {
+      el.setAttribute("aria-describedby", tooltip.id);
+    });
+  });
+});


### PR DESCRIPTION
Note: A long term solution to this should be done in https://github.com/uswds/uswds/issues/4338

- 🌎 Some of our pages have a few hundred tooltips
- ⛔ USWDS assigns them all random ids, but the ids sometimes conflict! Especially on ci/cd, the random number generator is bad and conflicts happen dependably.
- ✅ This commit attempts to patch the issue by modying the ids after they've been
  generated
- 🔮 Future commits should remove this once upstream is fixed