### PR TITLE
Add height to hero image

### DIFF
--- a/_includes/landing/hero.html
+++ b/_includes/landing/hero.html
@@ -4,7 +4,7 @@
       role="img"
       aria-label="{{ include.hero.alt.desktop }}"
     ></span>
-    <img src="{{ '/assets/images/hero-mobile-2022.jpg' | relative_url }}" alt="'{{ include.hero.alt.mobile }}'" class="height-auto width-full desktop:display-none" />
+    <img src="{{ '/assets/images/hero-mobile-2022.jpg' | relative_url }}" alt="'{{ include.hero.alt.mobile }}'" class="height-full width-full desktop:display-none" />
     <div class="grid-container">
       <div class="grid-row grid-gap">
         <div class="desktop:grid-col-6">

--- a/assets/sass/custom/_landing.scss
+++ b/assets/sass/custom/_landing.scss
@@ -43,10 +43,15 @@ $arrow-height: 24px;
 .crt-landing--hero {
   padding-top: 0;
 
+  .width-full {
+    width: 100%;
+  }
+
   @include at-media(desktop) {
     background-image: url($theme-hero-image);
     background-repeat: no-repeat;
     background-size: cover;
+    height: 40vh;
     min-height: 400px;
     background-position: center;
     &.crt-landing-topics--hero {


### PR DESCRIPTION
This PR tries to mitigate a Layout Shift issue [issue](https://lookerstudio.google.com/u/0/reporting/bbc5698d-57bb-4969-9e07-68810b9fa348/page/9WDQB?params=%7B%22origin%22:%22https:%2F%2Fwww.ada.gov%22%7D) by setting widths for the hero image loading on the page.