### PR TITLE
Fix hero height

### DIFF
--- a/assets/sass/custom/_landing.scss
+++ b/assets/sass/custom/_landing.scss
@@ -51,7 +51,7 @@ $arrow-height: 24px;
     background-image: url($theme-hero-image);
     background-repeat: no-repeat;
     background-size: cover;
-    height: 40vh;
+    height: 75vh;
     min-height: 400px;
     background-position: center;
     &.crt-landing-topics--hero {


### PR DESCRIPTION
The hero height was too short of the text on some resolutions. This PR fixes it.