### PR TITLE
Add title ii and iii to manual_redirects

### DIFF
--- a/_data/manual_redirects.json
+++ b/_data/manual_redirects.json
@@ -1,4 +1,6 @@
 {
   "/index.html": null,
-  "/404.html": null
+  "/404.html": null,
+  "/law-and-regs/title-iii-regulations/": "/law-and-regs/regulations/title-iii-regulations/",
+  "/law-and-regs/title-ii-2010-regulations/": "/law-and-regs/regulations/title-ii-2010-regulations/"
 }


### PR DESCRIPTION
- 🌎 We recently changed the URLs for title ii and title iii
- ⛔ This causes problems for folks with bookmarked pages
- ✅ This commit adds a manual redirect from the old urls to the new ones.

Note that this will still result in 404's in the logs. They are redirected following the 404 via javascript.