### PR TITLE
Fix bug with expand accordions wrapper

### DIFF
--- a/assets/js/utils/expandAccordions/getAccordions.js
+++ b/assets/js/utils/expandAccordions/getAccordions.js
@@ -1,6 +1,6 @@
 // Grab all of the accordions and convert the Nodelist into an array:
 const getAccordions = () => {
-  const regexp = /accordion-expandable\-*/gm;
+  const regexp = /expandable\-*/gm;
   const accordions = Array.from(
     document.querySelectorAll('.expand div.usa-accordion__content')
   ).filter((accordion) => accordion.id.match(regexp));


### PR DESCRIPTION
The expand-accordions-wrapper currently doesn't work with the accordion component because the id matching JS to find the accordion content is looking for the incorrect id. This PR fixes that.