### PR TITLE
Remove intermediate breadcrumbs for notice pages

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -7,7 +7,10 @@
   </svg>
   <ol class="padding-left-1" vocab="http://schema.org/"
   typeof="BreadcrumbList" class="usa-breadcrumb__list">
-    {% assign crumbs = page.url | remove:'/index.html' | remove:'/es' | remove: '/notices' | remove: '/2022' | remove: '/11' | remove: '/16' | remove: '/2023' | remove: '/20' | remove: '/07' | split: '/' %}
+    {% assign crumbs = page.url | remove:'/index.html' | remove:'/es' | split: '/'%}
+    {% if page.url contains '/notices' %}
+    {% assign crumbs = crumbs | last %}
+    {% endif %}
     <li property="itemListElement"
     typeof="ListItem" class="usa-breadcrumb__list-item"><a property="item"
     typeof="WebPage" href="/"><span property="name">{{ site.primary_navigation[0].name[lang] }}</span></a><meta property="position" content="1" /></li>


### PR DESCRIPTION
Re: https://github.com/usdoj-crt/beta.ADA.gov-Project-Management/issues/985

- 🌎 The notice breadcrumbs show links to the year, month, etc of the notice
- ⛔ These pages don't actually exist, so those links 404
- ✅ This commit removes intermediate breadcrumbs for notices pages, so it now shows "Home > Notice title"

Notice page: <img width="1007" alt="image" src="https://github.com/usdoj-crt/beta-ada/assets/15126660/cbb68851-c0ea-4efc-8552-9f3535cc91bf">

Non-notice page: <img width="787" alt="image" src="https://github.com/usdoj-crt/beta-ada/assets/15126660/27722c44-0f77-4da7-88e5-9ccfb057be0b">

