### PR TITLE
Fix in page search on ada page

### DIFF
--- a/assets/js/expand-sidenav.js
+++ b/assets/js/expand-sidenav.js
@@ -3,7 +3,7 @@ const sidenav = () => {
   if (!sideNav) return;
   const expandButton = document.getElementById('expand-all');
   const expandText = document.querySelector('.expand-text');
-  const expandIcon = expandButton.querySelector('.usa-icon');
+  const expandIcon = expandButton?.querySelector('.usa-icon');
   const nav = document.querySelector('.usa-accordion.margin-bottom-2');
   function expandAll() {
     const submenuButtons = document.getElementsByClassName('usa-accordion__button');


### PR DESCRIPTION
This PR fixes a bug where the in page search was not working on /law-and-regs/ada/ because of an error with the expand button not being found on the page.