### PR TITLE
[FAQ 4] Add content for help resources

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,17 @@ primary_navigation:
     url:
       en: "/resources/"
       es: "/resources/"
+    children:
+    - name:
+        en: Guidance & Resource Materials
+        en-short: Resources
+        es: Guidance & Resource Materials
+      url: "/resources/"
+    - name:
+        en: Help
+        en-short: Help
+        es: Help
+      url: "/help/"
   - name:
       en: Law, Regulations & Standards
       en-short: Law & Regulations

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -20,4 +20,7 @@
   </li>
     {% include subnav.html collection = page.subnav level=0 %}
   </ul>
+{% if page.phonebox %}
+{% include phone-box.html %}
+{% endif %}
 </nav>

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -7,7 +7,8 @@ title: Help
 description: "We're here to help. Get answers to your questions, learn about popular topics, and find resources for more support."
 lead: "We're here to help. Get answers to your questions, learn about popular topics, and find resources for more support."
 lang: en
-sidenav: false
+sidenav: true
+phonebox: true
 ref: help
 ---
 
@@ -100,10 +101,10 @@ Below are some key documents:
 - [Effective Communication]({{ '/topics/effective-communication' | relative_url }})
 - [Mobility Devices]({{ '/topics/mobility-devices' | relative_url }})
 - [File a Complaint]({{ '/file-a-complaint' | relative_url }})
-- [Curb Ramps]({{ '/topics/TODO/' | relative_url }})
-- [Ramps]({{ '/topics/TODO/' | relative_url }})
-- [Accessible Routes]({{ '/topics/TODO/' | relative_url }})
-- [Door, Doorways and Gates]({{ '/topics/TODO/' | relative_url }})
+- [Curb Ramps]({{ '/law-and-regs/design-standards/2010-stds/#406-curb-ramps#section86' | relative_url }})
+- [Ramps]({{ '/law-and-regs/design-standards/2010-stds/#405-ramps#section85' | relative_url }})
+- [Accessible Routes]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }})
+- [Door, Doorways and Gates]({{ '/law-and-regs/design-standards/2010-stds/#404-doors-doorways-and-gates#section84' | relative_url }})
 
 </div>
 
@@ -111,11 +112,9 @@ Below are some key documents:
 
 ## Resources for New Construction and Alternations
 
-### For business that are open to public
+When state/local governments and businesses build or alter buildings or other facilities, they must make them accessible to people with disabilities. To make them accessible, state/local governments and businesses need to follow the [ADA Standards for Accessible Design](https://www.ada.gov/law-and-regs/design-standards/2010-stds/). The information below is intended to help get you started.
 
-When businesses build or alter buildings or other facilities, they must make them accessible to people with disabilities. To make them accessible, businesses need to follow the ADA Standards for Accessible Design. The information below is intended to help get you started.
-
-#### ADA Standards Basics
+### ADA Standards Basics
 
 {% details Chapter 1: Application and Administration expandable %}
 
@@ -135,7 +134,7 @@ When businesses build or alter buildings or other facilities, they must make the
 
 {% enddetails %}
 
-#### Common Topics
+### Common Topics
 
 {% details Accessible Routes expandable %}
 
@@ -163,94 +162,7 @@ Note: Sections cover sales and service areas, such as check-out aisles and sales
 
 {% enddetails %}
 
-{% details Dining Surface expandable %}
-
-[Section 226]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }}) and [902]({{ '/law-and-regs/design-standards/2010-stds/#902-dining-surfaces-and-work-surfaces#section133' | relative_url }})
-
-Also see:
-
-- [Section 206.2.5 (Restaurants and Cafeterias)]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }})
-- [Section 226.2 (Dispersion, applies to dining surfaces)]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }})
-
-{% enddetails %}
-
-{% details Dressing, Fitting, and Locker Rooms expandable %}
-
-[Section 222]({{ '/law-and-regs/design-standards/2010-stds/#222-dressing-fitting-and-locker-rooms#section48' | relative_url }}) and [803]({{ '/law-and-regs/design-standards/2010-stds/#803-dressing-fitting-and-locker-rooms#section122' | relative_url }})
-
-{% enddetails %}
-
-{% details Door, Doorways, and Gates expandable %}
-
-[Section 404]({{ '/law-and-regs/design-standards/2010-stds/#404-doors-doorways-and-gates#section84' | relative_url }})
-
-{% enddetails %}
-
-{% details Ramps expandable %}
-
-[Section 405]({{ '/law-and-regs/design-standards/2010-stds/#405-ramps#section85' | relative_url }})
-
-{% enddetails %}
-
-{% details Curb ramps expandable %}
-
-[Section 406]({{ '/law-and-regs/design-standards/2010-stds/#406-curb-ramps#section86' | relative_url }})
-
-{% enddetails %}
-
-### For State and Local Governments
-
-When state/local governments build or alter facilities, they must make them accessible to people with disabilities. To make them accessible, state/local governments need to follow the ADA Standards for Accessible Design. The information below is intended to help get you started.
-
-#### ADA Standards Basics
-
-{% details Chapter 1: Application and Administration expandable %}
-
-[Contains important information, including definitions for key terms used in the Standards.]({{ '/law-and-regs/design-standards/2010-stds/#101-purpose#subpart8' | relative_url }})
-
-{% enddetails %}
-
-{% details Chapter 2: Scoping expandable %}
-
-[Explains which elements and how many of them must be accessible. Scoping covers newly built facilities and altered portions of older facilities.]({{ '/law-and-regs/design-standards/2010-stds/#201-application#subpart9' | relative_url }})
-
-{% enddetails %}
-
-{% details Chapter 3 - 10: Design and Technical Requirements expandable %}
-
-[Provides design and technical requirements for elements, spaces, buildings, and facilities.]({{ '/law-and-regs/design-standards/2010-stds/#301-general#subpart10' | relative_url }})
-
-{% enddetails %}
-
-#### Common Topics
-
-{% details Accessible Routes expandable %}
-
-[Section 206]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }}) and [Chapter 4]({{ '/law-and-regs/design-standards/2010-stds/#401-general#subpart11' | relative_url }})
-
-{% enddetails %}
-
-{% details Parking Spaces expandable %}
-
-[Section 208]({{ '/law-and-regs/design-standards/2010-stds/#208-parking-spaces#section34' | relative_url }}) and [502]({{ '/law-and-regs/design-standards/2010-stds/#502-parking-spaces#section93' | relative_url }})
-
-Also see:
-
-- [Section 209.4 (Valet Parking)]({{ '/law-and-regs/design-standards/2010-stds/#209-passenger-loading-zones-and-bus-stops#section35' | relative_url }})
-- [Section 216 (Signs)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
-  - [216.5 exception #1 (Limited parking)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
-
-{% enddetails %}
-
-{% details Sales and Service expandable %}
-
-[Section 227]({{ '/law-and-regs/design-standards/2010-stds/#227-sales-and-service#section53' | relative_url }}) and [904]({{ '/law-and-regs/design-standards/2010-stds/#904-check-out-aisles-and-sales-and-service-counters#section135' | relative_url }})
-
-Note: Sections cover sales and service areas, such as check-out aisles and sales and service counters.
-
-{% enddetails %}
-
-{% details Dining Surface expandable %}
+{% details Dining Surfaces and Work Surfaces expandable %}
 
 [Section 226]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }}) and [902]({{ '/law-and-regs/design-standards/2010-stds/#902-dining-surfaces-and-work-surfaces#section133' | relative_url }})
 

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -106,3 +106,183 @@ Below are some key documents:
 - [Door, Doorways and Gates]({{ '/topics/TODO/' | relative_url }})
 
 </div>
+
+<div class="box-accordion">
+
+## Resources for New Construction and Alternations
+
+### For business that are open to public
+
+When businesses build or alter buildings or other facilities, they must make them accessible to people with disabilities. To make them accessible, businesses need to follow the ADA Standards for Accessible Design. The information below is intended to help get you started.
+
+#### ADA Standards Basics
+
+{% details Chapter 1: Application and Administration expandable %}
+
+[Contains important information, including definitions for key terms used in the Standards.]({{ '/law-and-regs/design-standards/2010-stds/#101-purpose#subpart8' | relative_url }})
+
+{% enddetails %}
+
+{% details Chapter 2: Scoping expandable %}
+
+[Explains which elements and how many of them must be accessible. Scoping covers newly built facilities and altered portions of older facilities.]({{ '/law-and-regs/design-standards/2010-stds/#201-application#subpart9' | relative_url }})
+
+{% enddetails %}
+
+{% details Chapter 3 - 10: Design and Technical Requirements expandable %}
+
+[Provides design and technical requirements for elements, spaces, buildings, and facilities.]({{ '/law-and-regs/design-standards/2010-stds/#301-general#subpart10' | relative_url }})
+
+{% enddetails %}
+
+#### Common Topics
+
+{% details Accessible Routes expandable %}
+
+[Section 206]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }}) and [Chapter 4]({{ '/law-and-regs/design-standards/2010-stds/#401-general#subpart11' | relative_url }})
+
+{% enddetails %}
+
+{% details Parking Spaces expandable %}
+
+[Section 208]({{ '/law-and-regs/design-standards/2010-stds/#208-parking-spaces#section34' | relative_url }}) and [502]({{ '/law-and-regs/design-standards/2010-stds/#502-parking-spaces#section93' | relative_url }})
+
+Also see:
+
+- [Section 209.4 (Valet Parking)]({{ '/law-and-regs/design-standards/2010-stds/#209-passenger-loading-zones-and-bus-stops#section35' | relative_url }})
+- [Section 216 (Signs)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
+  - [216.5 exception #1 (Limited parking)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
+
+{% enddetails %}
+
+{% details Sales and Service expandable %}
+
+[Section 227]({{ '/law-and-regs/design-standards/2010-stds/#227-sales-and-service#section53' | relative_url }}) and [904]({{ '/law-and-regs/design-standards/2010-stds/#904-check-out-aisles-and-sales-and-service-counters#section135' | relative_url }})
+
+Note: Sections cover sales and service areas, such as check-out aisles and sales and service counters.
+
+{% enddetails %}
+
+{% details Dining Surface expandable %}
+
+[Section 226]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }}) and [902]({{ '/law-and-regs/design-standards/2010-stds/#902-dining-surfaces-and-work-surfaces#section133' | relative_url }})
+
+Also see:
+
+- [Section 206.2.5 (Restaurants and Cafeterias)]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }})
+- [Section 226.2 (Dispersion, applies to dining surfaces)]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }})
+
+{% enddetails %}
+
+{% details Dressing, Fitting, and Locker Rooms expandable %}
+
+[Section 222]({{ '/law-and-regs/design-standards/2010-stds/#222-dressing-fitting-and-locker-rooms#section48' | relative_url }}) and [803]({{ '/law-and-regs/design-standards/2010-stds/#803-dressing-fitting-and-locker-rooms#section122' | relative_url }})
+
+{% enddetails %}
+
+{% details Door, Doorways, and Gates expandable %}
+
+[Section 404]({{ '/law-and-regs/design-standards/2010-stds/#404-doors-doorways-and-gates#section84' | relative_url }})
+
+{% enddetails %}
+
+{% details Ramps expandable %}
+
+[Section 405]({{ '/law-and-regs/design-standards/2010-stds/#405-ramps#section85' | relative_url }})
+
+{% enddetails %}
+
+{% details Curb ramps expandable %}
+
+[Section 406]({{ '/law-and-regs/design-standards/2010-stds/#406-curb-ramps#section86' | relative_url }})
+
+{% enddetails %}
+
+### For State and Local Governments
+
+When state/local governments build or alter facilities, they must make them accessible to people with disabilities. To make them accessible, state/local governments need to follow the ADA Standards for Accessible Design. The information below is intended to help get you started.
+
+#### ADA Standards Basics
+
+{% details Chapter 1: Application and Administration expandable %}
+
+[Contains important information, including definitions for key terms used in the Standards.]({{ '/law-and-regs/design-standards/2010-stds/#101-purpose#subpart8' | relative_url }})
+
+{% enddetails %}
+
+{% details Chapter 2: Scoping expandable %}
+
+[Explains which elements and how many of them must be accessible. Scoping covers newly built facilities and altered portions of older facilities.]({{ '/law-and-regs/design-standards/2010-stds/#201-application#subpart9' | relative_url }})
+
+{% enddetails %}
+
+{% details Chapter 3 - 10: Design and Technical Requirements expandable %}
+
+[Provides design and technical requirements for elements, spaces, buildings, and facilities.]({{ '/law-and-regs/design-standards/2010-stds/#301-general#subpart10' | relative_url }})
+
+{% enddetails %}
+
+#### Common Topics
+
+{% details Accessible Routes expandable %}
+
+[Section 206]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }}) and [Chapter 4]({{ '/law-and-regs/design-standards/2010-stds/#401-general#subpart11' | relative_url }})
+
+{% enddetails %}
+
+{% details Parking Spaces expandable %}
+
+[Section 208]({{ '/law-and-regs/design-standards/2010-stds/#208-parking-spaces#section34' | relative_url }}) and [502]({{ '/law-and-regs/design-standards/2010-stds/#502-parking-spaces#section93' | relative_url }})
+
+Also see:
+
+- [Section 209.4 (Valet Parking)]({{ '/law-and-regs/design-standards/2010-stds/#209-passenger-loading-zones-and-bus-stops#section35' | relative_url }})
+- [Section 216 (Signs)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
+  - [216.5 exception #1 (Limited parking)]({{ '/law-and-regs/design-standards/2010-stds/#216-signs#section42' | relative_url }})
+
+{% enddetails %}
+
+{% details Sales and Service expandable %}
+
+[Section 227]({{ '/law-and-regs/design-standards/2010-stds/#227-sales-and-service#section53' | relative_url }}) and [904]({{ '/law-and-regs/design-standards/2010-stds/#904-check-out-aisles-and-sales-and-service-counters#section135' | relative_url }})
+
+Note: Sections cover sales and service areas, such as check-out aisles and sales and service counters.
+
+{% enddetails %}
+
+{% details Dining Surface expandable %}
+
+[Section 226]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }}) and [902]({{ '/law-and-regs/design-standards/2010-stds/#902-dining-surfaces-and-work-surfaces#section133' | relative_url }})
+
+Also see:
+
+- [Section 206.2.5 (Restaurants and Cafeterias)]({{ '/law-and-regs/design-standards/2010-stds/#206-accessible-routes#section32' | relative_url }})
+- [Section 226.2 (Dispersion, applies to dining surfaces)]({{ '/law-and-regs/design-standards/2010-stds/#226-dining-surfaces-and-work-surfaces#section52' | relative_url }})
+
+{% enddetails %}
+
+{% details Dressing, Fitting, and Locker Rooms expandable %}
+
+[Section 222]({{ '/law-and-regs/design-standards/2010-stds/#222-dressing-fitting-and-locker-rooms#section48' | relative_url }}) and [803]({{ '/law-and-regs/design-standards/2010-stds/#803-dressing-fitting-and-locker-rooms#section122' | relative_url }})
+
+{% enddetails %}
+
+{% details Door, Doorways, and Gates expandable %}
+
+[Section 404]({{ '/law-and-regs/design-standards/2010-stds/#404-doors-doorways-and-gates#section84' | relative_url }})
+
+{% enddetails %}
+
+{% details Ramps expandable %}
+
+[Section 405]({{ '/law-and-regs/design-standards/2010-stds/#405-ramps#section85' | relative_url }})
+
+{% enddetails %}
+
+{% details Curb ramps expandable %}
+
+[Section 406]({{ '/law-and-regs/design-standards/2010-stds/#406-curb-ramps#section86' | relative_url }})
+
+{% enddetails %}
+
+</div>

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -110,7 +110,7 @@ Below are some key documents:
 
 <div class="box-accordion">
 
-## Resources for New Construction and Alternations
+## Resources for New Construction and Alterations
 
 When state/local governments and businesses build or alter buildings or other facilities, they must make them accessible to people with disabilities. To make them accessible, state/local governments and businesses need to follow the [ADA Standards for Accessible Design](https://www.ada.gov/law-and-regs/design-standards/2010-stds/). The information below is intended to help get you started.
 

--- a/_plugins/details.rb
+++ b/_plugins/details.rb
@@ -1,5 +1,8 @@
 module Jekyll
   class DetailsTag < Liquid::Block
+
+    @@ids = Hash.new(0)
+
     def initialize(tag_name, block_options, liquid_options)
       super
       @expand = ''
@@ -9,7 +12,10 @@ module Jekyll
         @expand = 'expand'
       end
       @title = @options.join(" ")
+
       @id = @options.join("-").downcase
+      @@ids[@id] += 1
+      @id += "-#{@@ids[@id]}" if @@ids[@id] > 1
     end
 
     def render(context)

--- a/assets/sass/custom/_accordion.scss
+++ b/assets/sass/custom/_accordion.scss
@@ -82,6 +82,10 @@
       border-bottom: 0;
       padding: 1em;
       background-position: right 1em center;
+
+      & > div {
+        padding-right: 2em;
+      }
     }
 
     details > div {

--- a/assets/sass/custom/_sidenav.scss
+++ b/assets/sass/custom/_sidenav.scss
@@ -67,12 +67,6 @@
       left: 0;
     }
 
-    .phone-box {
-      padding: 0.5em 1em;
-      font-size: .875rem;
-      background-color: #E6E6E6;
-      font-family: Public Sans Web, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol !important;
-    }
   }
 
   a:not(.crt-page--downloadpdf-button)  {
@@ -223,6 +217,13 @@
       }
     }
   }
+}
+
+.phone-box {
+  padding: 0.5em 1em;
+  font-size: .875rem;
+  background-color: #E6E6E6;
+  font-family: Public Sans Web, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol !important;
 }
 
 @media(max-width: 1023px) {


### PR DESCRIPTION
- 🌎 This content goes in the new help/FAQ page
- ✅ This commit adds a list of links between topics and relevant standards sections

<img width="1203" alt="Screenshot 2024-11-22 at 3 16 27 PM" src="https://github.com/user-attachments/assets/5695cd2a-1458-4711-9d3e-0affedc16bdd">

<img width="426" alt="Screenshot 2024-11-22 at 3 16 41 PM" src="https://github.com/user-attachments/assets/42dbda8d-60eb-488f-8c06-9a7e73b27da8">
