### PR TITLE
[ADA-1096] News Content Widget

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
     <div class="crt-landing--header crt-lightblue">
       <div class="padding-left-1 padding-right-1 border-bottom-0">
         <div class="grid-row width-full">
-          <div class="usa-logo" id="extended-logo">{% include logo.html %}</div>
+          <div class="usa-logo padding-left-3" id="extended-logo">{% include logo.html %}</div>
           <div class="grid-col-fill"></div>
           {% include phone.html %}
           <button aria-expanded="false" class="usa-menu-btn">{{site.data["en"]["i18n"].links.menu}}</button>

--- a/_includes/landing/hero.html
+++ b/_includes/landing/hero.html
@@ -25,16 +25,16 @@
     <div class="grid-row">
       <div class="desktop:grid-col-4">
         {% if include.hero.news-widget %}
-        <div class="bg-primary-darker margin-bottom-1">
+        <div class="crt-lightblue margin-bottom-1">
           <div class="padding-left-2 padding-right-2 padding-bottom-2">
             {% if include.hero.news-widget.title %}
-            <h2 class="padding-top-1 text__reverse font-heading-lg">
+            <h2 class="padding-top-1 font-heading-lg">
               {{ include.hero.news-widget.title}}
             </h2>
             {% endif %}
             {% if include.hero.news-widget.link %}
             <div class="padding-bottom-05">
-              <a class="text-no-underline usa-button usa-button--base" href="{{ include.hero.news-widget.link.href | relative_url }}">
+              <a class="text-no-underline usa-button" href="{{ include.hero.news-widget.link.href | relative_url }}">
                 {{ include.hero.news-widget.link.text }}
               </a>
             </div>

--- a/_includes/landing/hero.html
+++ b/_includes/landing/hero.html
@@ -1,24 +1,48 @@
 <div class="crt-landing--section crt-landing--hero crt-white" markdown="0">
-    <span
-      class="display-none desktop:display-inline"
-      role="img"
-      aria-label="{{ include.hero.alt.desktop }}"
-    ></span>
-    <img src="{{ '/assets/images/hero-mobile-2022.jpg' | relative_url }}" alt="'{{ include.hero.alt.mobile }}'" class="height-full width-full desktop:display-none" />
-    <div class="grid-container">
-      <div class="grid-row grid-gap">
-        <div class="desktop:grid-col-6">
-          <h1 class="pa11y-skip">
-            {{ include.hero.heading }}
-          </h1>
+  <span
+    class="display-none desktop:display-inline"
+    role="img"
+    aria-label="{{ include.hero.alt.desktop }}"
+  ></span>
+  <img src="{{ '/assets/images/hero-mobile-2022.jpg' | relative_url }}" alt="'{{ include.hero.alt.mobile }}'" class="height-full width-full desktop:display-none" />
+  <div class="grid-container">
+    <div class="grid-row">
+      <div class="desktop:grid-col-6">
+        <h1 class="font-heading-xl">
+          {{ include.hero.heading }}
+        </h1>
+        {% if include.hero.content %}
         <div aria-hidden="true" class="desktop:grid-col-2 tablet:display-none"></div>
-          <div class="crt-landing--separator"></div>
-          <div class="crt-landing--paragraph-wrapper">
+        <div class="crt-landing--separator"></div>
+        <div class="crt-landing--paragraph-wrapper">
           <p class="crt-landing--largetext pa11y-skip">
             {{ include.hero.content }}
           </p>
         </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="grid-row">
+      <div class="desktop:grid-col-4">
+        {% if include.hero.news-widget %}
+        <div class="bg-primary-darker margin-bottom-1">
+          <div class="padding-left-2 padding-right-2 padding-bottom-2">
+            {% if include.hero.news-widget.title %}
+            <h2 class="padding-top-1 text__reverse font-heading-lg">
+              {{ include.hero.news-widget.title}}
+            </h2>
+            {% endif %}
+            {% if include.hero.news-widget.link %}
+            <div class="padding-bottom-05">
+              <a class="text-no-underline usa-button usa-button--base" href="{{ include.hero.news-widget.link.href | relative_url }}">
+                {{ include.hero.news-widget.link.text }}
+              </a>
+            </div>
+            {% endif %}
+          </div>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>
+</div>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -29,10 +29,10 @@ hero:
 # 'news-widget' is an information box that shows on underneath the heading, and underneath content if it is populated. It is used to highlight and link to a particular news item.
   news-widget:
     title: |-
-      ADA Compliance Brief: Restriping Parking Spaces
+      Find out more about our work in the Civil Rights Division
     link:
       text: Learn More
-      href: https://ada.gov/feedback/
+      href: https://www.justice.gov/crt/our-work
 
 understand:
   heading: Topics

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,10 +19,20 @@ hero:
       Three people, two with visible disabilities, relaxing and talking outside.
     mobile: |-
       Five people, some with visible disabilities, hanging out on a rooftop deck while talking and laughing.
-  content: |-
-    Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
   heading: |-
     The Americans with Disabilities Act (ADA) protects people with disabilities from discrimination.
+
+# 'content' is a section of text that displays underneath the heading.
+  content: |-
+    Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
+
+# 'news-widget' is an information box that shows on underneath the heading, and underneath content if it is populated. It is used to highlight and link to a particular news item.
+  news-widget:
+    title: |-
+      ADA Compliance Brief: Restriping Parking Spaces
+    link:
+      text: Learn More
+      href: https://ada.gov/feedback/
 
 understand:
   heading: Topics

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -21,18 +21,14 @@ hero:
       Five people, some with visible disabilities, hanging out on a rooftop deck while talking and laughing.
   heading: |-
     The Americans with Disabilities Act (ADA) protects people with disabilities from discrimination.
-
-# 'content' is a section of text that displays underneath the heading.
-  # content: |-
-  #   Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
-
-# 'news-widget' is an information box that shows on underneath the heading, and underneath content if it is populated. It is used to highlight and link to a particular news item.
-  news-widget:
-    title: |-
-      Find out more about our work in the Civil Rights Division
-    link:
-      text: Learn More
-      href: https://www.justice.gov/crt/our-work
+  content: |-
+   Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
+  # news-widget:
+  #   title: |-
+  #
+  #   link:
+  #     text: 
+  #     href:
 
 understand:
   heading: Topics

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -23,8 +23,8 @@ hero:
     The Americans with Disabilities Act (ADA) protects people with disabilities from discrimination.
 
 # 'content' is a section of text that displays underneath the heading.
-  content: |-
-    Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
+  # content: |-
+  #   Disability rights are civil rights. From voting to parking, the ADA is a law that protects people with disabilities in many areas of public life.
 
 # 'news-widget' is an information box that shows on underneath the heading, and underneath content if it is populated. It is used to highlight and link to a particular news item.
   news-widget:

--- a/assets/sass/custom/_landing.scss
+++ b/assets/sass/custom/_landing.scss
@@ -51,8 +51,6 @@ $arrow-height: 24px;
     background-image: url($theme-hero-image);
     background-repeat: no-repeat;
     background-size: cover;
-    height: 75vh;
-    min-height: 400px;
     background-position: center;
     &.crt-landing-topics--hero {
       background-image: url('../images/laws-and-regs-lp.jpeg');


### PR DESCRIPTION
This pull request implements a news content widget for use on the homepage. It is currently defined in index.md underneath the 'hero' section and is part of the hero template html.

Note: The content in the news content module in this PR is currently placeholder. Currently it links to: https://www.justice.gov/crt/our-work

## Screenshots
<img width="469" alt="Screenshot 2025-01-08 at 2 36 46 PM" src="https://github.com/user-attachments/assets/8c5658f3-ccc7-43f2-b2e9-c74a44a8e356" />
