### PR TITLE
Add an ignore rule for pa11y to ignore frames

### DIFF
--- a/.pa11yci-desktop
+++ b/.pa11yci-desktop
@@ -9,7 +9,8 @@
     "standard": "WCAG2AA",
     "runners": ["axe"],
     "ignore": [
-      "color-contrast"
+      "color-contrast",
+      "frame-tested"
     ],
     "timeout": 240000
   }

--- a/.pa11yci-mobile
+++ b/.pa11yci-mobile
@@ -13,7 +13,8 @@
       "axe"
     ],
     "ignore": [
-      "color-contrast"
+      "color-contrast",
+      "frame-tested"
     ],
     "timeout": 240000,
     "viewport": {


### PR DESCRIPTION
We want to embed frames into the site but pa11y wants them to be tested by default. We are not the authors of content that gets embedded into the site by frames, so we can disable this rule.