### PR TITLE
Upgrade content grid to v4

### DIFF
--- a/.github/workflows/content-grid.yml
+++ b/.github/workflows/content-grid.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./create_content_grid.sh
 
       - name: Archive content grid results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: content_grid
           path: ./scripts/out/content_grid.csv


### PR DESCRIPTION
The content grid is failing to publish because of a deprecated "upload artifacts" action.

This upgrades the action.