### PR TITLE
Update accessibility workflow a11y.yml to use non-deprecated versions

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Disable AppArmor
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Install Ruby Dependencies

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -3,11 +3,15 @@ on: [push]
 jobs:
   build:
     name: Run Accessibility Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+
+      - name: Disable AppArmor
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Install Ruby Dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js Dependencies
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "20"
       - run: npm install
 
       - name: Start Server

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   build:
     name: Run Accessibility Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Source


### PR DESCRIPTION
Ubuntu version 20.04 is deprecated and has a scheduled brownout for today, meaning this workflow will fail. I have updated the Ubuntu version used by this workflow to `ubuntu-latest` as recommended.